### PR TITLE
Add custom workout creation

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Exercise } from '@shared/schema';
+import { exerciseLibrary } from '@/lib/exercise-library';
+import { ExerciseOption } from '@/lib/exercise-library';
+
+interface CustomWorkoutBuilderModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (name: string, exercises: Exercise[]) => void;
+}
+
+export function CustomWorkoutBuilderModal({ open, onClose, onCreate }: CustomWorkoutBuilderModalProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [name, setName] = useState('');
+
+  const toggle = (machine: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(machine)) {
+        next.delete(machine);
+      } else if (next.size < 15) {
+        next.add(machine);
+      }
+      return next;
+    });
+  };
+
+  const handleCreate = () => {
+    if (name.trim() === '' || selected.size === 0) return;
+    const exercises: Exercise[] = Array.from(selected).map(m => {
+      const info = exerciseLibrary.find(e => e.machine === m)!;
+      return {
+        machine: info.machine,
+        region: info.region,
+        feel: 'Medium',
+        completed: false,
+        sets: [
+          { weight: undefined, reps: undefined, rest: '', completed: false },
+          { weight: undefined, reps: undefined, rest: '', completed: false },
+          { weight: undefined, reps: undefined, rest: '', completed: false },
+        ],
+      } as Exercise;
+    });
+    onCreate(name, exercises);
+    setName('');
+    setSelected(new Set());
+  };
+
+  const warning12 = selected.size >= 12 && selected.size < 15;
+  const warning15 = selected.size === 15;
+
+  const grouped: Record<string, ExerciseOption[]> = {};
+  exerciseLibrary.forEach(e => {
+    if (!grouped[e.region]) grouped[e.region] = [];
+    grouped[e.region].push(e);
+  });
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="space-y-4 overflow-y-auto max-h-[80vh]">
+        <DialogHeader>
+          <DialogTitle>Create Custom Workout</DialogTitle>
+          <DialogDescription>Select up to 15 exercises and give your workout a name.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {Object.entries(grouped).map(([region, exercises]) => (
+            <div key={region} className="border rounded p-2">
+              <div className="font-medium mb-2">{region}</div>
+              <div className="grid grid-cols-2 gap-2">
+                {exercises.map(ex => (
+                  <label key={ex.machine} className="flex items-center space-x-2 text-sm">
+                    <Checkbox checked={selected.has(ex.machine)} onCheckedChange={() => toggle(ex.machine)} />
+                    <span>{ex.machine}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        {warning12 && (
+          <p className="text-yellow-600 text-sm">⚠️ That’s a big session — are you training or moving in?</p>
+        )}
+        {warning15 && (
+          <p className="text-red-600 text-sm">🚨 Danger: Too many exercises in one session isn’t effective. Consider splitting it up.</p>
+        )}
+        <Input placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
+        <Button onClick={handleCreate} disabled={name.trim() === '' || selected.size === 0}>Save Workout</Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -6,14 +6,17 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { CustomWorkoutTemplate } from '@/lib/storage';
 
 interface WorkoutTemplateSelectorModalProps {
   open: boolean;
+  customTemplates: CustomWorkoutTemplate[];
   onClose: () => void;
   onSelectTemplate: (template: string) => void;
+  onCreateCustom: () => void;
 }
 
-export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }: WorkoutTemplateSelectorModalProps) {
+export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom }: WorkoutTemplateSelectorModalProps) {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose();
@@ -47,6 +50,19 @@ export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }
           <Button variant="outline" onClick={() => onSelectTemplate('Chest & Triceps')}>Chest & Triceps</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Chest & Shoulders')}>Chest & Shoulders</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Chest, Shoulders & Legs')}>Chest, Shoulders & Legs</Button>
+
+          {customTemplates.length > 0 && (
+            <div className="pt-2 border-t border-gray-200 dark:border-gray-700 space-y-2">
+              <div className="text-sm font-medium text-gray-600 dark:text-gray-400">Custom Workouts</div>
+              {customTemplates.map(t => (
+                <Button key={t.id} variant="outline" onClick={() => onSelectTemplate(t.name)}>
+                  {t.name}
+                </Button>
+              ))}
+            </div>
+          )}
+
+          <Button variant="secondary" onClick={onCreateCustom}>➕ Create custom workout</Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/client/src/lib/exercise-library.ts
+++ b/client/src/lib/exercise-library.ts
@@ -1,0 +1,18 @@
+import { workoutTemplates } from '@/lib/workout-data';
+
+export interface ExerciseOption {
+  machine: string;
+  region: string;
+}
+
+export const exerciseLibrary: ExerciseOption[] = (() => {
+  const map = new Map<string, ExerciseOption>();
+  Object.values(workoutTemplates).forEach(template => {
+    template?.exercises.forEach(ex => {
+      if (!map.has(ex.machine)) {
+        map.set(ex.machine, { machine: ex.machine, region: ex.region });
+      }
+    });
+  });
+  return Array.from(map.values()).sort((a, b) => a.region.localeCompare(b.region));
+})();


### PR DESCRIPTION
## Summary
- support saving custom workout templates in local storage
- add UI to browse all exercises and create custom workouts
- expose custom templates via workout storage hook
- update calendar page to allow building and selecting custom workouts

## Testing
- `npm run check`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c987b34688329992571ed68e034d0