### PR TITLE
Make rest optional and default on completion

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -17,7 +17,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   const { toast } = useToast();
 
   const isSetComplete = (set: ExerciseSet) =>
-    set.weight !== undefined && set.reps !== undefined && set.rest.trim() !== '';
+    set.weight !== undefined && set.reps !== undefined;
 
   const updateSet = (
     setIndex: number,
@@ -40,10 +40,13 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
     if (!isSetComplete(set)) {
       toast({
         title: 'Set incomplete',
-        description: 'Enter weight, reps and rest first',
+        description: 'Enter weight and reps first',
         variant: 'destructive'
       });
       return;
+    }
+    if ((set.rest ?? '').trim() === '') {
+      updateSet(setIndex, 'rest', '1:00');
     }
     updateSet(setIndex, 'completed', true);
   };
@@ -53,12 +56,20 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
     if (!allSetsComplete) {
       toast({
         title: 'Exercise incomplete',
-        description: 'Fill all fields for each set first',
+        description: 'Fill weight and reps for each set first',
         variant: 'destructive'
       });
       return;
     }
-    const updatedExercise = { ...localExercise, completed: !localExercise.completed };
+    const updatedSets = localExercise.sets.map((s) => ({
+      ...s,
+      rest: (s.rest ?? '').trim() === '' ? '1:00' : s.rest,
+    }));
+    const updatedExercise = {
+      ...localExercise,
+      sets: updatedSets,
+      completed: !localExercise.completed,
+    };
     setLocalExercise(updatedExercise);
     onUpdate(updatedExercise);
   };
@@ -116,7 +127,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
             const status = getSetStatus(set, index);
             const weightError = set.weight === undefined;
             const repsError = set.reps === undefined;
-            const restError = set.rest.trim() === '';
+            const restError = (set.rest ?? '').trim() === '' && set.completed;
             
             return (
               <div
@@ -169,7 +180,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="text"
-                  value={set.rest}
+                  value={set.rest ?? ''}
                   onChange={(e) => updateSet(index, 'rest', e.target.value)}
                   className={`w-16 text-sm ${restError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="rest"

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -70,7 +70,7 @@ export class LocalWorkoutStorage {
           s =>
             s.weight === undefined ||
             s.reps === undefined ||
-            s.rest.trim() === ''
+            (s.rest ?? '').trim() === ''
         )
       ) {
         continue;

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -119,10 +119,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const cardioComplete = workout.cardio?.completed || false;
     const allFieldsFilled = workout.exercises.every(ex =>
       ex.sets.every(
-        s =>
-          s.weight !== undefined &&
-          s.reps !== undefined &&
-          s.rest.trim() !== ''
+        s => s.weight !== undefined && s.reps !== undefined
       )
     );
 
@@ -135,10 +132,23 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       return;
     }
 
+    const completedExercises = workout.exercises.map((e) =>
+      e.completed
+        ? {
+            ...e,
+            sets: e.sets.map((s) => ({
+              ...s,
+              rest: (s.rest ?? '').trim() === '' ? '1:00' : s.rest,
+            })),
+          }
+        : e
+    );
+
     const completedWorkout = {
       ...workout,
+      exercises: completedExercises,
       completed: true,
-      duration: calculateWorkoutDuration()
+      duration: calculateWorkoutDuration(),
     };
     
     setWorkout(completedWorkout);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 const exerciseSetSchema = z.object({
   weight: z.number().optional(),
   reps: z.number().optional(),
-  rest: z.string(), // e.g., "1:30"
+  rest: z.string().optional(), // e.g., "1:30"
   completed: z.boolean().default(false)
 });
 


### PR DESCRIPTION
## Summary
- allow exercise sets to omit rest field in shared schema
- relax UI validation to ignore missing rest
- default rest to `1:00` when sets or exercises are completed
- persist defaults when completing a workout
- handle optional rest in local storage history logic

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_686d22a5c2c883298667fcfb7217d06c