### PR TITLE
Add auto-schedule flag for custom workouts

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -17,7 +17,12 @@ import { absLibrary, AbsExerciseOption } from '@/lib/abs-library';
 interface CustomWorkoutBuilderModalProps {
   open: boolean;
   onClose: () => void;
-  onCreate: (name: string, exercises: Exercise[], abs: AbsExercise[]) => void;
+  onCreate: (
+    name: string,
+    exercises: Exercise[],
+    abs: AbsExercise[],
+    includeInAutoSchedule: boolean,
+  ) => void;
   existingNames: string[];
 }
 
@@ -25,6 +30,7 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [selectedAbs, setSelectedAbs] = useState<Set<string>>(new Set());
   const [name, setName] = useState('');
+  const [includeInSchedule, setIncludeInSchedule] = useState(false);
 
   const toggle = (machine: string) => {
     setSelected(prev => {
@@ -77,10 +83,11 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
         completed: false,
       } as AbsExercise;
     });
-    onCreate(name, exercises, abs);
+    onCreate(name, exercises, abs, includeInSchedule);
     setName('');
     setSelected(new Set());
     setSelectedAbs(new Set());
+    setIncludeInSchedule(false);
   };
 
   const warning12 = selected.size >= 12 && selected.size < 15;
@@ -141,6 +148,13 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
           <p className="text-red-600 text-sm">🚨 Danger: Too many exercises in one session isn’t effective. Consider splitting it up.</p>
         )}
         <Input placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
+        <label className="flex items-center space-x-2 text-sm">
+          <Checkbox
+            checked={includeInSchedule}
+            onCheckedChange={v => setIncludeInSchedule(!!v)}
+          />
+          <span>Include in auto-schedule</span>
+        </label>
         {isDuplicate && (
           <p className="text-red-600 text-sm">Workout name must be unique</p>
         )}

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -151,7 +151,9 @@ export function useWorkoutStorage() {
     return success;
   };
 
-  const addCustomTemplate = async (template: Omit<CustomWorkoutTemplate, 'id'>) => {
+  const addCustomTemplate = async (
+    template: Omit<CustomWorkoutTemplate, 'id'>,
+  ) => {
     const newTemplate = await localWorkoutStorage.addCustomTemplate(template);
     setCustomTemplates(prev => [...prev, newTemplate]);
     return newTemplate;


### PR DESCRIPTION
## Summary
- extend `CustomWorkoutTemplate` with `includeInAutoSchedule`
- support saving/loading this flag in local storage
- expose `getWorkoutCycle()` that merges default cycle with opted-in custom workouts
- update schedule generation and workout starting logic
- add option in CustomWorkoutBuilderModal to include templates in the auto-schedule

## Testing
- `npm run check`
- `npx vitest run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d53415c048329aceeb6279ce6ee18