### PR TITLE
Enable editing of custom workouts

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -53,7 +53,7 @@ export function CustomWorkoutBuilderModal({
       if (template) {
         setName(template.name);
         setSelected(new Set(template.exercises.map(e => e.machine)));
-        setSelectedAbs(new Set(template.abs.map(a => a.name)));
+        setSelectedAbs(new Set((template.abs ?? []).map(a => a.name)));
         setIncludeInSchedule(template.includeInAutoSchedule ?? false);
       } else {
         setName('');

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Exercise, AbsExercise } from '@shared/schema';
+import { CustomWorkoutTemplate } from '@/lib/storage';
 import { exerciseLibrary } from '@/lib/exercise-library';
 import { ExerciseOption } from '@/lib/exercise-library';
 import { absLibrary, AbsExerciseOption } from '@/lib/abs-library';
@@ -23,14 +24,45 @@ interface CustomWorkoutBuilderModalProps {
     abs: AbsExercise[],
     includeInAutoSchedule: boolean,
   ) => void;
+  onUpdate?: (
+    id: number,
+    name: string,
+    exercises: Exercise[],
+    abs: AbsExercise[],
+    includeInAutoSchedule: boolean,
+  ) => void;
+  template?: CustomWorkoutTemplate | null;
   existingNames: string[];
 }
 
-export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNames }: CustomWorkoutBuilderModalProps) {
+export function CustomWorkoutBuilderModal({
+  open,
+  onClose,
+  onCreate,
+  onUpdate,
+  template,
+  existingNames,
+}: CustomWorkoutBuilderModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [selectedAbs, setSelectedAbs] = useState<Set<string>>(new Set());
   const [name, setName] = useState('');
   const [includeInSchedule, setIncludeInSchedule] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      if (template) {
+        setName(template.name);
+        setSelected(new Set(template.exercises.map(e => e.machine)));
+        setSelectedAbs(new Set(template.abs.map(a => a.name)));
+        setIncludeInSchedule(template.includeInAutoSchedule ?? false);
+      } else {
+        setName('');
+        setSelected(new Set());
+        setSelectedAbs(new Set());
+        setIncludeInSchedule(false);
+      }
+    }
+  }, [open, template]);
 
   const toggle = (machine: string) => {
     setSelected(prev => {
@@ -56,9 +88,11 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
     });
   };
 
-  const isDuplicate = existingNames.some(n => n.toLowerCase() === name.trim().toLowerCase());
+  const isDuplicate = existingNames
+    .filter(n => !template || n.toLowerCase() !== template.name.toLowerCase())
+    .some(n => n.toLowerCase() === name.trim().toLowerCase());
 
-  const handleCreate = () => {
+  const handleSave = () => {
     if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
     const exercises: Exercise[] = Array.from(selected).map(m => {
       const info = exerciseLibrary.find(e => e.machine === m)!;
@@ -83,11 +117,12 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
         completed: false,
       } as AbsExercise;
     });
-    onCreate(name, exercises, abs, includeInSchedule);
-    setName('');
-    setSelected(new Set());
-    setSelectedAbs(new Set());
-    setIncludeInSchedule(false);
+    if (template && onUpdate) {
+      onUpdate(template.id, name, exercises, abs, includeInSchedule);
+    } else {
+      onCreate(name, exercises, abs, includeInSchedule);
+    }
+    onClose();
   };
 
   const warning12 = selected.size >= 12 && selected.size < 15;
@@ -109,7 +144,7 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="space-y-4 overflow-y-auto max-h-[80vh]">
         <DialogHeader>
-          <DialogTitle>Create Custom Workout</DialogTitle>
+          <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
           <DialogDescription>Select up to 15 exercises and give your workout a name.</DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
@@ -158,7 +193,9 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNam
         {isDuplicate && (
           <p className="text-red-600 text-sm">Workout name must be unique</p>
         )}
-        <Button onClick={handleCreate} disabled={name.trim() === '' || selected.size === 0 || isDuplicate}>Save Workout</Button>
+        <Button onClick={handleSave} disabled={name.trim() === '' || selected.size === 0 || isDuplicate}>
+          {template ? 'Update Workout' : 'Save Workout'}
+        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -7,6 +7,13 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { CustomWorkoutTemplate } from '@/lib/storage';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { Settings } from 'lucide-react';
 
 interface WorkoutTemplateSelectorModalProps {
   open: boolean;
@@ -15,9 +22,10 @@ interface WorkoutTemplateSelectorModalProps {
   onSelectTemplate: (template: string) => void;
   onCreateCustom: () => void;
   onDeleteTemplate: (id: number) => void;
+  onEditTemplate: (template: CustomWorkoutTemplate) => void;
 }
 
-export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onDeleteTemplate }: WorkoutTemplateSelectorModalProps) {
+export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onDeleteTemplate, onEditTemplate }: WorkoutTemplateSelectorModalProps) {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose();
@@ -64,17 +72,27 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
                   >
                     {t.name}
                   </Button>
-                  <Button
-                    variant="ghost"
-                    className="text-red-600"
-                    onClick={() => {
-                      if (confirm('Are you sure you want to delete this workout?')) {
-                        onDeleteTemplate(t.id);
-                      }
-                    }}
-                  >
-                    ✕
-                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <Settings className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => onEditTemplate(t)}>
+                        Edit workout
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          if (confirm('Delete this workout?')) {
+                            onDeleteTemplate(t.id);
+                          }
+                        }}
+                      >
+                        Delete workout
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               ))}
             </div>

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -167,6 +167,19 @@ export function useWorkoutStorage() {
     return success;
   };
 
+  const updateCustomTemplate = async (
+    id: number,
+    updates: Omit<CustomWorkoutTemplate, 'id'>,
+  ) => {
+    const updated = await localWorkoutStorage.updateCustomTemplate(id, updates);
+    if (updated) {
+      setCustomTemplates(prev =>
+        prev.map(t => (t.id === id ? updated : t)),
+      );
+    }
+    return updated;
+  };
+
 
   const resetAllData = async () => {
     await localWorkoutStorage.clearAllData();
@@ -189,6 +202,7 @@ export function useWorkoutStorage() {
     deleteWorkout,
     addCustomTemplate,
     deleteCustomTemplate,
+    updateCustomTemplate,
     resetAllData,
     exportData,
     exportCSV

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -188,6 +188,19 @@ export class LocalWorkoutStorage {
     return true;
   }
 
+  async updateCustomTemplate(
+    id: number,
+    updates: Omit<CustomWorkoutTemplate, 'id'>,
+  ): Promise<CustomWorkoutTemplate | undefined> {
+    const templates = this.getCustomTemplatesInternal();
+    const index = templates.findIndex(t => t.id === id);
+    if (index === -1) return undefined;
+    const updated = { ...templates[index], ...updates };
+    templates[index] = updated;
+    this.saveCustomTemplates(templates);
+    return updated;
+  }
+
   async getUserPreferences(): Promise<UserPreferences> {
     const stored = localStorage.getItem(STORAGE_KEYS.PREFERENCES);
     const defaultPrefs: UserPreferences = {

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -1,9 +1,10 @@
-import { Workout, InsertWorkout, UserPreferences, Exercise } from "@shared/schema";
+import { Workout, InsertWorkout, UserPreferences, Exercise, AbsExercise } from "@shared/schema";
 
 export interface CustomWorkoutTemplate {
   id: number;
   name: string;
   exercises: Exercise[];
+  abs?: AbsExercise[];
   includeInAutoSchedule?: boolean;
 }
 
@@ -53,6 +54,7 @@ export class LocalWorkoutStorage {
     const templates = stored ? JSON.parse(stored) : [];
     return templates.map((t: CustomWorkoutTemplate) => ({
       includeInAutoSchedule: false,
+      abs: [],
       ...t,
     }));
   }
@@ -174,7 +176,12 @@ export class LocalWorkoutStorage {
   async addCustomTemplate(template: Omit<CustomWorkoutTemplate, 'id'>): Promise<CustomWorkoutTemplate> {
     const templates = this.getCustomTemplatesInternal();
     const id = templates.length > 0 ? Math.max(...templates.map(t => t.id)) + 1 : 1;
-    const newTemplate: CustomWorkoutTemplate = { id, includeInAutoSchedule: template.includeInAutoSchedule ?? false, ...template };
+    const newTemplate: CustomWorkoutTemplate = {
+      id,
+      includeInAutoSchedule: template.includeInAutoSchedule ?? false,
+      abs: template.abs ?? [],
+      ...template,
+    };
     templates.push(newTemplate);
     this.saveCustomTemplates(templates);
     return newTemplate;
@@ -195,7 +202,11 @@ export class LocalWorkoutStorage {
     const templates = this.getCustomTemplatesInternal();
     const index = templates.findIndex(t => t.id === id);
     if (index === -1) return undefined;
-    const updated = { ...templates[index], ...updates };
+    const updated = {
+      ...templates[index],
+      ...updates,
+      abs: updates.abs ?? templates[index].abs ?? [],
+    };
     templates[index] = updated;
     this.saveCustomTemplates(templates);
     return updated;

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -96,7 +96,12 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     include: boolean,
   ) => {
     if (!dateForCreation) return;
-    await addCustomTemplate({ name, exercises, includeInAutoSchedule: include });
+    await addCustomTemplate({
+      name,
+      exercises,
+      abs,
+      includeInAutoSchedule: include,
+    });
     await createWorkout({
       date: dateForCreation,
       type: name,

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -9,6 +9,7 @@ import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
 import { Workout, Exercise, AbsExercise } from '@shared/schema';
+import { CustomWorkoutTemplate } from '@/lib/storage';
 
 interface CalendarPageProps {
   onNavigateToWorkout: (workout: Workout) => void;
@@ -20,6 +21,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [customBuilderOpen, setCustomBuilderOpen] = useState(false);
+  const [templateToEdit, setTemplateToEdit] = useState<CustomWorkoutTemplate | null>(null);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
   const {
     workouts,
@@ -29,6 +31,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     deleteWorkout,
     addCustomTemplate,
     deleteCustomTemplate,
+    updateCustomTemplate,
     customTemplates,
     loading
   } = useWorkoutStorage();
@@ -109,6 +112,28 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     await loadWorkoutForDate(dateForCreation);
     setCustomBuilderOpen(false);
     setDateForCreation(null);
+  };
+
+  const handleCustomWorkoutUpdate = async (
+    id: number,
+    name: string,
+    exercises: Exercise[],
+    abs: AbsExercise[],
+    include: boolean,
+  ) => {
+    await updateCustomTemplate(id, {
+      name,
+      exercises,
+      abs,
+      includeInAutoSchedule: include,
+    });
+    setTemplateToEdit(null);
+  };
+
+  const handleEditCustomTemplate = (template: CustomWorkoutTemplate) => {
+    setTemplateModalOpen(false);
+    setTemplateToEdit(template);
+    setCustomBuilderOpen(true);
   };
 
   const handleDeleteCustomTemplate = async (id: number) => {
@@ -421,11 +446,14 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onSelectTemplate={handleTemplateSelect}
         onCreateCustom={handleCreateCustom}
         onDeleteTemplate={handleDeleteCustomTemplate}
+        onEditTemplate={handleEditCustomTemplate}
       />
       <CustomWorkoutBuilderModal
         open={customBuilderOpen}
-        onClose={() => setCustomBuilderOpen(false)}
+        onClose={() => { setCustomBuilderOpen(false); setTemplateToEdit(null); }}
         onCreate={handleCustomWorkoutCreate}
+        onUpdate={handleCustomWorkoutUpdate}
+        template={templateToEdit ?? undefined}
         existingNames={customTemplates.map(t => t.name)}
       />
     </div>


### PR DESCRIPTION
## Summary
- add update function for custom workout templates
- extend workout storage hook to update custom templates
- update builder modal to support editing
- add gear menu in template selector for editing/deleting
- wire up editing flow in calendar page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d59a5ebe08329b0eea8903fbfa191