### PR TITLE
Fix toast memory leak

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -6,7 +6,9 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Time (ms) before a dismissed toast is fully removed from state
+// Keep this short to avoid accumulating timers and DOM nodes
+const TOAST_REMOVE_DELAY = 500
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten the toast removal delay so dismissed toasts clean up quickly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6d34f6f883298eebbafad4408102