### PR TITLE
Add auto schedule customization UI

### DIFF
--- a/client/src/components/AutoScheduleModal.tsx
+++ b/client/src/components/AutoScheduleModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { localWorkoutStorage, CustomWorkoutTemplate } from '@/lib/storage';
+import { defaultWorkoutCycle } from '@/lib/workout-data';
+
+interface AutoScheduleModalProps {
+  open: boolean;
+  onClose: () => void;
+  customTemplates?: CustomWorkoutTemplate[];
+}
+
+export function AutoScheduleModal({ open, onClose, customTemplates }: AutoScheduleModalProps) {
+  const presetNames = Array.from(new Set(defaultWorkoutCycle));
+  const [templates, setTemplates] = useState<CustomWorkoutTemplate[]>(customTemplates ?? []);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (open && !customTemplates) {
+      localWorkoutStorage.getCustomTemplates().then(setTemplates);
+    }
+  }, [open, customTemplates]);
+
+  useEffect(() => {
+    if (open) {
+      const stored = localWorkoutStorage.getAutoScheduleWorkouts();
+      let initial: string[];
+      if (stored.length === 0) {
+        initial = [
+          ...presetNames,
+          ...templates.filter(t => t.includeInAutoSchedule).map(t => t.name),
+        ];
+      } else {
+        initial = stored;
+      }
+      setSelected(new Set(initial));
+    }
+  }, [open, templates, presetNames]);
+
+  const toggle = (name: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    const list = Array.from(selected);
+    if (list.length === 0) return;
+    localWorkoutStorage.saveAutoScheduleWorkouts(list);
+    onClose();
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>Customize Auto-Schedule</DialogTitle>
+          <DialogDescription>
+            Choose which workouts appear in the automatic rotation.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 max-h-[60vh] overflow-y-auto">
+          <div>
+            <div className="font-medium mb-2">Presets</div>
+            <div className="space-y-2">
+              {presetNames.map(name => (
+                <label key={name} className="flex items-center space-x-2 text-sm">
+                  <Checkbox checked={selected.has(name)} onCheckedChange={() => toggle(name)} />
+                  <span>{name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          {templates.length > 0 && (
+            <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <div className="font-medium mb-2">My Workouts</div>
+              <div className="space-y-2">
+                {templates.map(t => (
+                  <label key={t.id} className="flex items-center space-x-2 text-sm">
+                    <Checkbox checked={selected.has(t.name)} onCheckedChange={() => toggle(t.name)} />
+                    <span>{t.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        <Button onClick={handleSave} disabled={selected.size === 0} className="w-full">
+          Save
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -4,10 +4,12 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog';
 import { localWorkoutStorage } from '@/lib/storage';
+import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { toast } from '@/hooks/use-toast';
 
 export function SettingsDialog({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
 
   const handleExport = async () => {
     const data = await localWorkoutStorage.exportData();
@@ -34,9 +36,10 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="space-y-4">
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{children}</DialogTrigger>
+        <DialogContent className="space-y-4">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription>Manage app data and preferences.</DialogDescription>
@@ -51,6 +54,9 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
               </Button>
             </label>
           </div>
+          <Button className="w-full" variant="secondary" onClick={() => setScheduleOpen(true)}>
+            Customize Auto-Schedule
+          </Button>
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="destructive" className="w-full">Reset All Data</Button>
@@ -73,7 +79,9 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           Created by Casey Flanigan<br />
           This is an open source project which can be found here: https://github.com/crflanigan/IronPath
         </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      <AutoScheduleModal open={scheduleOpen} onClose={() => setScheduleOpen(false)} />
+    </>
   );
 }

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -13,7 +13,8 @@ const STORAGE_KEYS = {
   PREFERENCES: 'ironpath_preferences',
   CURRENT_ID: 'ironpath_current_id',
   EXERCISE_HISTORY: 'ironpath_exercise_history',
-  CUSTOM_TEMPLATES: 'ironpath_custom_templates'
+  CUSTOM_TEMPLATES: 'ironpath_custom_templates',
+  AUTO_SCHEDULE_WORKOUTS: 'ironpath_auto_schedule_workouts'
 } as const;
 
 interface ExerciseHistoryEntry {
@@ -69,6 +70,22 @@ export class LocalWorkoutStorage {
     } catch {
       return [];
     }
+  }
+
+  getAutoScheduleWorkouts(): string[] {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.AUTO_SCHEDULE_WORKOUTS);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  saveAutoScheduleWorkouts(names: string[]): void {
+    localStorage.setItem(
+      STORAGE_KEYS.AUTO_SCHEDULE_WORKOUTS,
+      JSON.stringify(names)
+    );
   }
 
   async getLastExerciseSets(machine: string): Promise<{ weight: number; reps: number; rest?: string }[] | undefined> {

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -879,11 +879,23 @@ export const defaultWorkoutCycle: string[] = [
 ];
 
 export function getWorkoutCycle(): string[] {
-  const customs = localWorkoutStorage
-    .getCustomTemplatesSync()
-    .filter(t => t.includeInAutoSchedule)
+  const selected = localWorkoutStorage.getAutoScheduleWorkouts();
+  const customTemplates = localWorkoutStorage.getCustomTemplatesSync();
+
+  const presets =
+    selected.length === 0
+      ? defaultWorkoutCycle
+      : defaultWorkoutCycle.filter(name => selected.includes(name));
+
+  const customs = customTemplates
+    .filter(t =>
+      selected.length === 0
+        ? t.includeInAutoSchedule
+        : selected.includes(t.name)
+    )
     .map(t => t.name);
-  return [...defaultWorkoutCycle, ...customs];
+
+  return [...presets, ...customs];
 }
 
 // Generate workout schedule for a given month

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -8,6 +8,7 @@ import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from 
 import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
+import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate } from '@/lib/storage';
 
@@ -21,6 +22,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [customBuilderOpen, setCustomBuilderOpen] = useState(false);
+  const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [templateToEdit, setTemplateToEdit] = useState<CustomWorkoutTemplate | null>(null);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
   const {
@@ -421,16 +423,24 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
                 onDelete={handleDeleteSelectedWorkout}
               />
             )}
-            <div className="text-center py-4">
-              {!selectedWorkout && (
-                <p className="text-gray-600 dark:text-gray-400 mb-4">
-                  No custom workout scheduled for this date
-                </p>
-              )}
-              <Button onClick={() => openTemplateSelector(selectedDate)}>
-                {selectedWorkout ? 'Create Custom Workout' : 'Create Workout'}
-              </Button>
-            </div>
+              <div className="text-center py-4 space-y-2">
+                {!selectedWorkout && (
+                  <p className="text-gray-600 dark:text-gray-400 mb-4">
+                    No custom workout scheduled for this date
+                  </p>
+                )}
+                <div className="flex justify-center space-x-2">
+                  <Button onClick={() => openTemplateSelector(selectedDate)}>
+                    {selectedWorkout ? 'Create Custom Workout' : 'Create Workout'}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setScheduleModalOpen(true)}
+                  >
+                    Customize Auto-Schedule
+                  </Button>
+                </div>
+              </div>
           </CardContent>
         </Card>
       )}
@@ -453,14 +463,19 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onDeleteTemplate={handleDeleteCustomTemplate}
         onEditTemplate={handleEditCustomTemplate}
       />
-      <CustomWorkoutBuilderModal
-        open={customBuilderOpen}
-        onClose={() => { setCustomBuilderOpen(false); setTemplateToEdit(null); }}
-        onCreate={handleCustomWorkoutCreate}
-        onUpdate={handleCustomWorkoutUpdate}
-        template={templateToEdit ?? undefined}
-        existingNames={customTemplates.map(t => t.name)}
-      />
-    </div>
-  );
-}
+        <CustomWorkoutBuilderModal
+          open={customBuilderOpen}
+          onClose={() => { setCustomBuilderOpen(false); setTemplateToEdit(null); }}
+          onCreate={handleCustomWorkoutCreate}
+          onUpdate={handleCustomWorkoutUpdate}
+          template={templateToEdit ?? undefined}
+          existingNames={customTemplates.map(t => t.name)}
+        />
+        <AutoScheduleModal
+          open={scheduleModalOpen}
+          onClose={() => setScheduleModalOpen(false)}
+          customTemplates={customTemplates}
+        />
+      </div>
+    );
+  }


### PR DESCRIPTION
## Summary
- add storage of auto schedule workout selections
- update schedule generation logic to use saved selections
- provide AutoScheduleModal component for choosing workouts
- expose customization from Calendar page and Settings dialog

## Testing
- `npm run check --silent`
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686dbd8662b483299342acb18fa766da