### PR TITLE
Move message above custom workout button

### DIFF
--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -427,15 +427,15 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
               />
             )}
 
-            <Button className="w-full" onClick={() => openTemplateSelector(selectedDate)}>
-              Create Custom Workout
-            </Button>
-
             {!selectedWorkout && (
               <p className="text-center text-gray-600 dark:text-gray-400">
                 No custom workout scheduled for this date
               </p>
             )}
+
+            <Button className="w-full" onClick={() => openTemplateSelector(selectedDate)}>
+              Create Custom Workout
+            </Button>
 
             <Button
               className="w-full"


### PR DESCRIPTION
## Summary
- reorder markup in CalendarPage so the 'No custom workout scheduled for this date' message sits above the "Create Custom Workout" button

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd68ac2c88329ae76a97bb0e3dbd3