### PR TITLE
Enhance workout form inputs

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -50,11 +50,10 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
       });
       return;
     }
-    if ((set.rest ?? '').trim() === '') {
-      updateSet(setIndex, 'rest', '1:00');
-    }
+
     const updatedSets = [...localExercise.sets];
-    updatedSets[setIndex] = { ...updatedSets[setIndex], completed: true };
+    const rest = (set.rest ?? '').trim() === '' ? '1:00' : set.rest;
+    updatedSets[setIndex] = { ...updatedSets[setIndex], rest, completed: true };
 
     const exerciseCompleted = updatedSets.every(s => s.completed);
     const updatedExercise = {
@@ -132,14 +131,14 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="number"
+                  inputMode="decimal"
                   value={set.weight ?? ''}
-                  onChange={(e) =>
-                    updateSet(
-                      index,
-                      'weight',
-                      e.target.value === '' ? undefined : parseInt(e.target.value)
-                    )
-                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (/^\d*$/.test(v)) {
+                      updateSet(index, 'weight', v === '' ? undefined : parseInt(v));
+                    }
+                  }}
                   className={`w-16 text-sm ${weightError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="lbs"
                   disabled={false}
@@ -149,14 +148,14 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="number"
+                  inputMode="decimal"
                   value={set.reps ?? ''}
-                  onChange={(e) =>
-                    updateSet(
-                      index,
-                      'reps',
-                      e.target.value === '' ? undefined : parseInt(e.target.value)
-                    )
-                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (/^\d*$/.test(v)) {
+                      updateSet(index, 'reps', v === '' ? undefined : parseInt(v));
+                    }
+                  }}
                   className={`w-14 text-sm ${repsError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="reps"
                   disabled={false}
@@ -164,8 +163,21 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="text"
+                  inputMode="numeric"
+                  pattern="[0-9:]*"
                   value={set.rest ?? ''}
-                  onChange={(e) => updateSet(index, 'rest', e.target.value)}
+                  onChange={(e) => {
+                    const digits = e.target.value.replace(/\D/g, '').slice(0, 3);
+                    if (digits.length === 0) {
+                      updateSet(index, 'rest', '');
+                      return;
+                    }
+                    const formatted =
+                      digits.length <= 2
+                        ? `0:${digits.padStart(2, '0')}`
+                        : `${parseInt(digits.slice(0, -2))}:${digits.slice(-2)}`;
+                    updateSet(index, 'rest', formatted);
+                  }}
                   className={`w-16 text-sm ${restError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="rest"
                   disabled={false}


### PR DESCRIPTION
## Summary
- allow only digits in weight and reps fields and show numeric keypad
- format rest fields while typing and restrict to `m:ss`
- auto-fill empty rest fields when completing a set

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8219d7248329b0b7cde91bee5f7a