### PR TITLE
Add instructional image modal

### DIFF
--- a/client/public/exercise-images/placeholder.svg
+++ b/client/public/exercise-images/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#e5e7eb" />
+  <text x="200" y="150" fill="#6b7280" font-size="24" text-anchor="middle" dy="0.3em">No Image</text>
+</svg>

--- a/client/src/components/ExerciseImageDialog.tsx
+++ b/client/src/components/ExerciseImageDialog.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+
+interface ExerciseImageDialogProps {
+  exerciseName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ExerciseImageDialog({
+  exerciseName,
+  open,
+  onOpenChange
+}: ExerciseImageDialogProps) {
+  const [error, setError] = useState(false);
+  const slug = exerciseName
+    .toLowerCase()
+    .replace(/\(.*?\)/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\-]/g, '');
+  const src = `/exercise-images/${slug}.jpg`;
+
+  const handleError = () => setError(true);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 max-w-md">
+        <DialogHeader className="p-4 pb-0">
+          <DialogTitle>{exerciseName}</DialogTitle>
+        </DialogHeader>
+        {!error ? (
+          <img
+            src={src}
+            alt={exerciseName}
+            onError={handleError}
+            className="w-full h-auto object-contain"
+          />
+        ) : (
+          <img
+            src="/exercise-images/placeholder.svg"
+            alt="Placeholder"
+            className="w-full h-auto object-contain p-6"
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -3,7 +3,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Exercise, ExerciseSet } from '@shared/schema';
-import { Check, Clock } from 'lucide-react';
+import { Check, Clock, HelpCircle } from 'lucide-react';
+import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';
 
 interface ExerciseFormProps {
@@ -17,6 +18,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   const [restDigits, setRestDigits] = useState<string[]>(
     exercise.sets.map((s) => s.rest?.replace(/\D/g, '') || '')
   );
+  const [showHelp, setShowHelp] = useState(false);
   const { toast } = useToast();
 
   const isSetComplete = (set: ExerciseSet) =>
@@ -101,6 +103,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                      isActive ? 'border-blue-500' : 'border-gray-300 dark:border-gray-600';
 
   return (
+    <>
     <Card className={`border-l-4 ${borderColor}`}>
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-3">
@@ -111,6 +114,14 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
             </p>
           </div>
           <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={() => setShowHelp(true)}
+              className="text-gray-500 hover:text-primary"
+            >
+              <HelpCircle className="h-5 w-5" />
+              <span className="sr-only">Help</span>
+            </button>
             {localExercise.completed && <Check className="h-5 w-5 text-green-500" />}
             {isActive && !localExercise.completed && <Clock className="h-5 w-5 text-blue-500" />}
           </div>
@@ -238,5 +249,11 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
         </div>
       </CardContent>
     </Card>
+    <ExerciseImageDialog
+      exerciseName={localExercise.machine}
+      open={showHelp}
+      onOpenChange={setShowHelp}
+    />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- show help icon per strength exercise
- display instructional image in responsive dialog
- include placeholder image if no image exists
- fix file extension to `.jpg`

## Testing
- `npm run check`
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb3216364832991499ae0e388ed1b