### PR TITLE
Rename 'Rear Delt / Pec Fly' exercise

### DIFF
--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -41,7 +41,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       },
       {
         code: "S4",
-        machine: "Rear Delt / Pec Fly",
+        machine: "Pec Fly",
         region: "Outer Pecs",
         feel: "Medium",
         sets: [


### PR DESCRIPTION
## Summary
- rename exercise label from **Rear Delt / Pec Fly** to **Pec Fly**

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6872d7d4fd188329b89dea0b2aa3ff5a