### PR TITLE
Implement localStorage versioning

### DIFF
--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -4,13 +4,31 @@ import { localWorkoutStorage, CustomWorkoutTemplate } from '@/lib/storage';
 import { workoutTemplates } from '@/lib/workout-data';
 import { formatLocalDate } from '@/lib/utils';
 
+const STORAGE_VERSION = "1.0.0";
+const VERSION_KEY = "ironpath_version";
+
 export function useWorkoutStorage() {
   const [workouts, setWorkouts] = useState<Workout[]>([]);
   const [preferences, setPreferences] = useState<UserPreferences | null>(null);
   const [customTemplates, setCustomTemplates] = useState<CustomWorkoutTemplate[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const checkStorageVersion = () => {
+    try {
+      const currentVersion = localStorage.getItem(VERSION_KEY);
+      if (currentVersion !== STORAGE_VERSION) {
+        Object.keys(localStorage).forEach((key) => {
+          if (key.startsWith('ironpath')) localStorage.removeItem(key);
+        });
+        localStorage.setItem(VERSION_KEY, STORAGE_VERSION);
+      }
+    } catch (err) {
+      console.error('Failed to verify storage version', err);
+    }
+  };
+
   useEffect(() => {
+    checkStorageVersion();
     loadData();
   }, []);
 
@@ -25,7 +43,7 @@ export function useWorkoutStorage() {
       // If there are no workouts stored, simply start with an empty list.
       // The previous implementation would regenerate a schedule, leaving
       // counters unchanged after a reset.
-      const resolvedWorkouts = workoutsData ?? [];
+      const resolvedWorkouts = (workoutsData ?? []).filter(Boolean);
 
       setWorkouts(resolvedWorkouts);
       setPreferences(prefsData);

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -34,7 +34,8 @@ export class LocalWorkoutStorage {
 
   private getWorkouts(): Workout[] {
     const stored = localStorage.getItem(STORAGE_KEYS.WORKOUTS);
-    return stored ? JSON.parse(stored) : [];
+    const parsed = stored ? JSON.parse(stored) : [];
+    return Array.isArray(parsed) ? parsed.filter(Boolean) : [];
   }
 
   private saveWorkouts(workouts: Workout[]): void {
@@ -52,7 +53,8 @@ export class LocalWorkoutStorage {
 
   private getCustomTemplatesInternal(): CustomWorkoutTemplate[] {
     const stored = localStorage.getItem(STORAGE_KEYS.CUSTOM_TEMPLATES);
-    const templates = stored ? JSON.parse(stored) : [];
+    const parsed = stored ? JSON.parse(stored) : [];
+    const templates = Array.isArray(parsed) ? parsed.filter(Boolean) : [];
     return templates.map((t: CustomWorkoutTemplate) => ({
       includeInAutoSchedule: false,
       abs: [],
@@ -75,7 +77,8 @@ export class LocalWorkoutStorage {
   getAutoScheduleWorkouts(): string[] {
     try {
       const stored = localStorage.getItem(STORAGE_KEYS.AUTO_SCHEDULE_WORKOUTS);
-      return stored ? JSON.parse(stored) : [];
+      const parsed = stored ? JSON.parse(stored) : [];
+      return Array.isArray(parsed) ? parsed.filter(Boolean) : [];
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary
- introduce `STORAGE_VERSION` and `VERSION_KEY` constants
- add version check and cleanup in `useWorkoutStorage`
- filter invalid entries from local storage on load

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6872f80a90288329b75a0a3494e0d0ac