### PR TITLE
Fix custom workout replacement

### DIFF
--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -62,6 +62,13 @@ export function useWorkoutStorage() {
 
 
   const createWorkout = async (workout: InsertWorkout) => {
+    // If a workout already exists on this date, remove it first to avoid duplicates
+    const existing = await localWorkoutStorage.getWorkoutByDate(workout.date);
+    if (existing) {
+      await localWorkoutStorage.deleteWorkout(existing.id);
+      setWorkouts(prev => prev.filter(w => w.id !== existing.id));
+    }
+
     // pre-fill exercises with last used weight, reps, and rest if available
     const exercisesWithHistory = await Promise.all(
       (workout.exercises as Exercise[]).map(async (ex) => {


### PR DESCRIPTION
## Summary
- remove existing workout for date before creating a new one

## Testing
- `npx vitest run`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687305663ccc8329ae044d0646795266