### PR TITLE
Update custom workout button label

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -98,7 +98,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             </div>
           )}
 
-          <Button variant="secondary" onClick={onCreateCustom}>➕ Create custom workout</Button>
+          <Button variant="secondary" onClick={onCreateCustom}>➕ Create or Edit Custom Workout</Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -434,7 +434,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
             )}
 
             <Button className="w-full" onClick={() => openTemplateSelector(selectedDate)}>
-              Create Custom Workout
+              Create or Edit Custom Workout
             </Button>
 
             <Button


### PR DESCRIPTION
## Summary
- clarify that users can create or edit a workout template from the calendar
- update modal button label for consistency

## Testing
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_687309f9c418832995b209e131c5c17e