### PR TITLE
Add preset cloning feature

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -32,6 +32,11 @@ interface CustomWorkoutBuilderModalProps {
     includeInAutoSchedule: boolean,
   ) => void;
   template?: CustomWorkoutTemplate | null;
+  prefill?: {
+    name: string;
+    exercises: Exercise[];
+    abs: AbsExercise[];
+  } | null;
   existingNames: string[];
 }
 
@@ -41,6 +46,7 @@ export function CustomWorkoutBuilderModal({
   onCreate,
   onUpdate,
   template,
+  prefill,
   existingNames,
 }: CustomWorkoutBuilderModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -55,6 +61,11 @@ export function CustomWorkoutBuilderModal({
         setSelected(new Set(template.exercises.map(e => e.machine)));
         setSelectedAbs(new Set((template.abs ?? []).map(a => a.name)));
         setIncludeInSchedule(template.includeInAutoSchedule ?? false);
+      } else if (prefill) {
+        setName(prefill.name);
+        setSelected(new Set(prefill.exercises.map(e => e.machine)));
+        setSelectedAbs(new Set((prefill.abs ?? []).map(a => a.name)));
+        setIncludeInSchedule(false);
       } else {
         setName('');
         setSelected(new Set());
@@ -62,7 +73,7 @@ export function CustomWorkoutBuilderModal({
         setIncludeInSchedule(false);
       }
     }
-  }, [open, template]);
+  }, [open, template, prefill]);
 
   const toggle = (machine: string) => {
     setSelected(prev => {

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -21,11 +21,12 @@ interface WorkoutTemplateSelectorModalProps {
   onClose: () => void;
   onSelectTemplate: (template: string) => void;
   onCreateCustom: () => void;
+  onClonePreset: (preset: string) => void;
   onDeleteTemplate: (id: number) => void;
   onEditTemplate: (template: CustomWorkoutTemplate) => void;
 }
 
-export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onDeleteTemplate, onEditTemplate }: WorkoutTemplateSelectorModalProps) {
+export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onClonePreset, onDeleteTemplate, onEditTemplate }: WorkoutTemplateSelectorModalProps) {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose();
@@ -42,23 +43,37 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col space-y-2">
-          <Button variant="outline" onClick={() => onSelectTemplate('Chest Day')}>Chest Day</Button>
-          {/*
-            Template keys are defined in workout-data.ts using
-            "Legs". Passing the mismatched label caused
-            workout creation to silently fail.
-          */}
-          <Button
-            variant="outline"
-            onClick={() => onSelectTemplate('Legs')}
-          >
-            Legs
-          </Button>
-          <Button variant="outline" onClick={() => onSelectTemplate('Back & Biceps')}>Back & Biceps</Button>
-          <Button variant="outline" onClick={() => onSelectTemplate('Back, Biceps & Legs')}>Back, Biceps & Legs</Button>
-          <Button variant="outline" onClick={() => onSelectTemplate('Chest & Triceps')}>Chest & Triceps</Button>
-          <Button variant="outline" onClick={() => onSelectTemplate('Chest & Shoulders')}>Chest & Shoulders</Button>
-          <Button variant="outline" onClick={() => onSelectTemplate('Chest, Shoulders & Legs')}>Chest, Shoulders & Legs</Button>
+          {[
+            'Chest Day',
+            'Legs',
+            'Back & Biceps',
+            'Back, Biceps & Legs',
+            'Chest & Triceps',
+            'Chest & Shoulders',
+            'Chest, Shoulders & Legs',
+          ].map(name => (
+            <div key={name} className="flex items-center space-x-1">
+              <Button
+                variant="outline"
+                className="flex-1 justify-start"
+                onClick={() => onSelectTemplate(name)}
+              >
+                {name}
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon">
+                    <Settings className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => onClonePreset(name)}>
+                    Clone as custom
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          ))}
 
           {customTemplates.length > 0 && (
             <div className="pt-2 border-t border-gray-200 dark:border-gray-700 space-y-2">

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -26,6 +26,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [customBuilderOpen, setCustomBuilderOpen] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [templateToEdit, setTemplateToEdit] = useState<CustomWorkoutTemplate | null>(null);
+  const [prefillTemplate, setPrefillTemplate] = useState<{ name: string; exercises: Exercise[]; abs: AbsExercise[] } | null>(null);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
   const {
     workouts,
@@ -64,6 +65,23 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
 
   const handleCreateCustom = () => {
     setTemplateModalOpen(false);
+    setCustomBuilderOpen(true);
+  };
+
+  const handleClonePreset = (presetName: string) => {
+    const builtIn = workoutTemplates[presetName as keyof typeof workoutTemplates];
+    if (!builtIn) return;
+    setTemplateModalOpen(false);
+    setTemplateToEdit(null);
+    setPrefillTemplate({
+      name: `Custom - ${presetName}`,
+      exercises: builtIn.exercises.map(ex => ({
+        ...ex,
+        completed: false,
+        sets: ex.sets.map(s => ({ ...s, completed: false })),
+      })),
+      abs: builtIn.abs.map(a => ({ ...a, completed: false })),
+    });
     setCustomBuilderOpen(true);
   };
 
@@ -120,6 +138,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     });
     await loadWorkoutForDate(dateForCreation);
     setCustomBuilderOpen(false);
+    setPrefillTemplate(null);
     setDateForCreation(null);
   };
 
@@ -453,15 +472,17 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onClose={() => setTemplateModalOpen(false)}
         onSelectTemplate={handleTemplateSelect}
         onCreateCustom={handleCreateCustom}
+        onClonePreset={handleClonePreset}
         onDeleteTemplate={handleDeleteCustomTemplate}
         onEditTemplate={handleEditCustomTemplate}
       />
         <CustomWorkoutBuilderModal
           open={customBuilderOpen}
-          onClose={() => { setCustomBuilderOpen(false); setTemplateToEdit(null); }}
+          onClose={() => { setCustomBuilderOpen(false); setTemplateToEdit(null); setPrefillTemplate(null); }}
           onCreate={handleCustomWorkoutCreate}
           onUpdate={handleCustomWorkoutUpdate}
           template={templateToEdit ?? undefined}
+          prefill={prefillTemplate ?? undefined}
           existingNames={customTemplates.map(t => t.name)}
         />
         <AutoScheduleModal


### PR DESCRIPTION
## Summary
- enable pre-fill support in `CustomWorkoutBuilderModal`
- add gear menus for preset templates that let you clone them
- wire up clone logic in calendar page

## Testing
- `npm run check`
- `npm test -- -t none` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730fb358848329b0af83b25964d97a