### PR TITLE
Fix iOS PWA icon

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,15 +9,13 @@
     
     <!-- PWA Meta Tags -->
     <link rel="manifest" href="/manifest.json" />
-    <!-- Ensure icon-192x192.png and icon-512x512.png exist in client/public/ -->
+    <!-- Ensure icon-180x180.png exists in client/public/ -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="IronPath" />
-    <link rel="apple-touch-icon" href="/icon-192x192.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/icon-180x180.png?v=3" />
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" sizes="192x192" href="/icon-192x192.png" />
-    <link rel="icon" type="image/png" sizes="512x512" href="/icon-512x512.png" />
     
     <!-- Open Graph Tags -->
     <meta property="og:title" content="IronPath - Workout Tracker" />

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -10,14 +10,8 @@
   "scope": "/",
   "icons": [
     {
-      "src": "/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icon-512x512.png",
-      "sizes": "512x512",
+      "src": "/icon-180x180.png?v=3",
+      "sizes": "180x180",
       "type": "image/png",
       "purpose": "maskable any"
     }
@@ -33,8 +27,8 @@
       "url": "/workout",
       "icons": [
         {
-          "src": "/icon-192x192.png",
-          "sizes": "192x192"
+          "src": "/icon-180x180.png?v=3",
+          "sizes": "180x180"
         }
       ]
     },
@@ -45,8 +39,8 @@
       "url": "/history",
       "icons": [
         {
-          "src": "/icon-192x192.png",
-          "sizes": "192x192"
+          "src": "/icon-180x180.png?v=3",
+          "sizes": "180x180"
         }
       ]
     }

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -3,8 +3,7 @@ const CACHE_NAME = `ironpath-${CACHE_VERSION}`;
 const urlsToCache = [
   '/',
   '/manifest.json',
-  '/icon-192x192.png',
-  '/icon-512x512.png',
+  '/icon-180x180.png?v=3',
   // Add other static assets here
 ];
 
@@ -99,8 +98,8 @@ self.addEventListener('push', event => {
     const data = event.data.json();
     const options = {
       body: data.body,
-      icon: '/icon-192x192.png',
-      badge: '/icon-192x192.png',
+      icon: '/icon-180x180.png?v=3',
+      badge: '/icon-180x180.png?v=3',
       actions: [
         {
           action: 'open',


### PR DESCRIPTION
## Summary
- update the apple-touch-icon link to 180x180
- remove outdated 192x192/512x512 icons
- update manifest and service worker to reference the new icon

## Testing
- `npm run check`
- `npm test` *(exits watcher with CTRL+C)*

------
https://chatgpt.com/codex/tasks/task_e_687426abc54c8329ab88aaa920e2d1eb