### PR TITLE
Use 'freeweight' for non-machine exercises

### DIFF
--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -16,6 +16,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S24",
         machine: "Adjustable Cable Crossover",
+        equipment: "machine",
         region: "Chest Pecs",
         feel: "Medium",
         sets: [
@@ -29,6 +30,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S5",
         machine: "Converging Chest Press",
+        equipment: "machine",
         region: "Chest Pecs",
         feel: "Medium",
         sets: [
@@ -42,6 +44,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S4",
         machine: "Pec Fly",
+        equipment: "machine",
         region: "Outer Pecs",
         feel: "Medium",
         sets: [
@@ -55,6 +58,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S12",
         machine: "Lateral Raise",
+        equipment: "freeweight",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -68,6 +72,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S33",
         machine: "Lateral Raise Machine",
+        equipment: "machine",
         region: "Shoulders",
         feel: "Light",
         sets: [
@@ -81,6 +86,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S24",
         machine: "High-Pulley Kick Back",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -94,6 +100,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S8",
         machine: "Seated Dip",
+        equipment: "machine",
         region: "Outer Triceps",
         feel: "Medium",
         sets: [
@@ -119,6 +126,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S36",
         machine: "Seated Leg Press",
+        equipment: "machine",
         region: "Legs (Warm Up)",
         feel: "N/A",
         sets: [
@@ -132,6 +140,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S22",
         machine: "45 Degree Leg Press",
+        equipment: "machine",
         region: "Quads / Hams",
         feel: "Heavy",
         sets: [
@@ -145,6 +154,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Body Squat",
+        equipment: "both",
         region: "Legs",
         feel: "Medium",
         sets: [
@@ -158,6 +168,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S14",
         machine: "Seated Leg Curl",
+        equipment: "machine",
         region: "Hamstrings",
         feel: "Medium",
         sets: [
@@ -171,6 +182,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S15",
         machine: "Seated Leg Extension",
+        equipment: "machine",
         region: "Quads",
         feel: "Medium",
         sets: [
@@ -184,6 +196,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S16",
         machine: "Adductor",
+        equipment: "machine",
         region: "Inner Thighs",
         feel: "Medium",
         sets: [
@@ -197,6 +210,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S18",
         machine: "Abductor",
+        equipment: "machine",
         region: "Outer Thighs",
         feel: "Medium",
         sets: [
@@ -210,6 +224,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S17",
         machine: "Glute Machine",
+        equipment: "machine",
         region: "Glutes",
         feel: "Medium",
         sets: [
@@ -223,6 +238,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "S3",
         machine: "Standing Calf Raise (1-DB)",
+        equipment: "freeweight",
         region: "Calves",
         feel: "Medium",
         sets: [
@@ -249,6 +265,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Wide Grip Pulldown (front)",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -262,6 +279,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Close Grip Pulldown (front)",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -275,6 +293,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Row",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -288,6 +307,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Back Extension",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -301,6 +321,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Bent Over Rear Deltoid",
+        equipment: "freeweight",
         region: "Shoulders",
         feel: "Light",
         sets: [
@@ -314,6 +335,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Low-Pulley Straight Bar Curl",
+        equipment: "machine",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -327,6 +349,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Low-Pulley 1-Arm Curl",
+        equipment: "machine",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -340,6 +363,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Shrug",
+        equipment: "freeweight",
         region: "Traps",
         feel: "Medium",
         sets: [
@@ -353,6 +377,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Standing Wrist Curl with Extension",
+        equipment: "freeweight",
         region: "Forearms",
         feel: "Light",
         sets: [
@@ -366,6 +391,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Bar Curl",
+        equipment: "freeweight",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -392,6 +418,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Wide Grip Pulldown (front)",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -405,6 +432,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Row",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -418,6 +446,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Herculean Dabble Curl",
+        equipment: "freeweight",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -431,6 +460,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Low-Pulley Straight Bar Curl",
+        equipment: "machine",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -444,6 +474,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "1-Arm Curl with Twist",
+        equipment: "freeweight",
         region: "Biceps",
         feel: "Medium",
         sets: [
@@ -457,6 +488,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Back Extension",
+        equipment: "machine",
         region: "Back",
         feel: "Medium",
         sets: [
@@ -470,6 +502,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Leg Extension",
+        equipment: "machine",
         region: "Quads",
         feel: "Medium",
         sets: [
@@ -483,6 +516,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "45 Degree Leg Press",
+        equipment: "machine",
         region: "Quads / Hams",
         feel: "Medium",
         sets: [
@@ -496,6 +530,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Glute Machine",
+        equipment: "machine",
         region: "Glutes",
         feel: "Medium",
         sets: [
@@ -509,6 +544,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Standing 1 Leg (1-DB) Calf Raise",
+        equipment: "freeweight",
         region: "Calves",
         feel: "Medium",
         sets: [
@@ -535,6 +571,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Chest Press",
+        equipment: "machine",
         region: "Chest",
         feel: "Medium",
         sets: [
@@ -548,6 +585,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Adjustable Cable Crossover",
+        equipment: "machine",
         region: "Chest",
         feel: "Medium",
         sets: [
@@ -561,6 +599,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Kick Back",
+        equipment: "both",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -574,6 +613,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Straight Bar Pushdown",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -587,6 +627,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Low-Pulley Kick Back",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -600,6 +641,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Lateral Raise",
+        equipment: "freeweight",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -626,6 +668,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Chest Press",
+        equipment: "machine",
         region: "Chest",
         feel: "Medium",
         sets: [
@@ -639,6 +682,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Push Up (on Knees)",
+        equipment: "both",
         region: "Chest",
         feel: "Light",
         sets: [
@@ -652,6 +696,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Shoulder Press",
+        equipment: "machine",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -665,6 +710,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Cable Front Deltoid Raise",
+        equipment: "machine",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -678,6 +724,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Lateral Raise",
+        equipment: "freeweight",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -691,6 +738,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Standing Shrug",
+        equipment: "freeweight",
         region: "Traps",
         feel: "Medium",
         sets: [
@@ -704,6 +752,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Standing Barbell Shrug",
+        equipment: "freeweight",
         region: "Traps",
         feel: "Medium",
         sets: [
@@ -717,6 +766,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Straight Bar Pushdown",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -730,6 +780,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "V-Bar Pushdown",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -755,6 +806,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Adjustable Cable Crossover",
+        equipment: "machine",
         region: "Chest Pecs",
         feel: "Medium",
         sets: [
@@ -768,6 +820,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Shoulder Press",
+        equipment: "machine",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -781,6 +834,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "V-Bar Pushdown",
+        equipment: "machine",
         region: "Triceps",
         feel: "Medium",
         sets: [
@@ -794,6 +848,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Leg Press",
+        equipment: "machine",
         region: "Quads / Hams",
         feel: "Medium",
         sets: [
@@ -807,6 +862,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Leg Extension",
+        equipment: "machine",
         region: "Quads",
         feel: "Medium",
         sets: [
@@ -820,6 +876,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Leg Curl",
+        equipment: "machine",
         region: "Hamstrings",
         feel: "Medium",
         sets: [
@@ -833,6 +890,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Glute Machine",
+        equipment: "machine",
         region: "Glutes",
         feel: "Medium",
         sets: [
@@ -846,6 +904,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Standing 1 Leg (1-DB) Calf Raise",
+        equipment: "freeweight",
         region: "Calves",
         feel: "Medium",
         sets: [

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -14,6 +14,7 @@ const exerciseSetSchema = z.object({
 const exerciseSchema = z.object({
   code: z.string().optional(), // Machine code like "S16"
   machine: z.string(),
+  equipment: z.enum(["machine", "freeweight", "both"]),
   region: z.string(),
   feel: z.enum(["Light", "Medium", "Hard", "Heavy", "N/A"]),
   sets: z.array(exerciseSetSchema),


### PR DESCRIPTION
## Summary
- replace the `dumbbell` equipment designation with `freeweight`
- update type schema to reflect the new equipment option

## Testing
- `npm run check`
- `yes | npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6877c83aa3708329817af2c46421a766