### PR TITLE
Fix filter icon overlap on mobile

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -187,20 +187,22 @@ export function CustomWorkoutBuilderModal({
   return (
     <>
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="space-y-4 overflow-y-auto max-h-[90vh]">
-        <DialogHeader>
-          <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
-          <DialogDescription>Select up to 15 exercises and give your workout a name.</DialogDescription>
-          <p className="text-sm text-muted-foreground text-left">Tap any exercise name to preview it.</p>
-        </DialogHeader>
-        <button
-          type="button"
-          onClick={cycleFilter}
-          className="absolute right-4 top-10 flex flex-col items-center w-20 text-sm select-none cursor-pointer"
-        >
-          <span className="text-2xl leading-none">{filterLabel[equipmentFilter].icon}</span>
-          <span className="leading-none">{filterLabel[equipmentFilter].label}</span>
-        </button>
+      <DialogContent className="space-y-4 overflow-y-auto max-h-[90vh] relative">
+        <div className="relative pb-16">
+          <DialogHeader className="pr-24 sm:pr-0">
+            <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
+            <DialogDescription>Select up to 15 exercises and give your workout a name.</DialogDescription>
+            <p className="text-sm text-muted-foreground text-left">Tap any exercise name to preview it.</p>
+          </DialogHeader>
+          <button
+            type="button"
+            onClick={cycleFilter}
+            className="absolute right-4 top-full mt-2 flex flex-col items-center w-20 text-sm select-none cursor-pointer"
+          >
+            <span className="text-2xl leading-none">{filterLabel[equipmentFilter].icon}</span>
+            <span className="leading-none">{filterLabel[equipmentFilter].label}</span>
+          </button>
+        </div>
         <div className="space-y-4">
           {Object.entries(grouped).map(([region, exercises]) => (
             <div key={region} className="border rounded p-2">


### PR DESCRIPTION
## Summary
- place filter icon under header with absolute positioning
- add padding-right on small screens to prevent text overlap

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6878541554948329a6f0f883d42f6aec