### PR TITLE
Fix autosave memory leak

### DIFF
--- a/client/src/pages/workout.test.tsx
+++ b/client/src/pages/workout.test.tsx
@@ -1,0 +1,153 @@
+import { render, fireEvent, screen, act, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { WorkoutPage } from './workout';
+import { Workout } from '@shared/schema';
+
+const baseWorkout: Workout = {
+  id: 1,
+  date: '2024-01-01',
+  type: 'Chest Day',
+  exercises: [
+    {
+      code: undefined,
+      machine: 'Bench Press',
+      equipment: 'freeweight',
+      region: 'chest',
+      feel: 'Medium',
+      sets: [{ weight: 100, reps: 8, rest: '1:00', completed: false }],
+      bestWeight: undefined,
+      bestReps: undefined,
+      completed: false
+    }
+  ],
+  abs: [
+    { name: 'Crunches', reps: 20, time: undefined, completed: false }
+  ],
+  cardio: { type: 'Treadmill', duration: '', distance: '', completed: false },
+  completed: false,
+  duration: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+
+vi.mock('@/hooks/use-workout-storage', () => {
+  const mockUpdateWorkout = vi.fn();
+  return {
+    useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout })
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() })
+}));
+
+describe('Workout Auto-Save Memory Leak Fix', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not stack multiple timeouts during rapid state changes', async () => {
+    const { rerender } = render(
+      <WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />
+    );
+
+    for (let i = 0; i < 5; i++) {
+      const updated = { ...baseWorkout, duration: i };
+      rerender(<WorkoutPage workout={updated} onNavigateBack={() => {}} />);
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const { useWorkoutStorage } = await import('@/hooks/use-workout-storage');
+    expect(useWorkoutStorage().updateWorkout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cleanup timeout on component unmount', () => {
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    const { unmount } = render(
+      <WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />
+    );
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('should handle handleSave dependency changes correctly', async () => {
+    const workout2 = { ...baseWorkout, id: 2 };
+    const { rerender } = render(
+      <WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />
+    );
+    rerender(<WorkoutPage workout={workout2} onNavigateBack={() => {}} />);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const { useWorkoutStorage } = await import('@/hooks/use-workout-storage');
+    expect(useWorkoutStorage().updateWorkout).toHaveBeenCalledWith(workout2.id, expect.anything());
+  });
+});
+
+describe('Auto-Save Integration', () => {
+  it('should save workout data after 2 seconds of inactivity', async () => {
+    const { useWorkoutStorage } = await import('@/hooks/use-workout-storage');
+    const mockStorage = useWorkoutStorage();
+
+    render(<WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Weight'), { target: { value: '100' } });
+
+    await waitFor(() => {
+      expect(mockStorage.updateWorkout).toHaveBeenCalled();
+    }, { timeout: 2500 });
+  });
+
+  it('should not save during rapid changes until user stops', async () => {
+    const { useWorkoutStorage } = await import('@/hooks/use-workout-storage');
+    const mockStorage = useWorkoutStorage();
+
+    render(<WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Weight'), { target: { value: '100' } });
+    await new Promise(r => setTimeout(r, 500));
+    fireEvent.change(screen.getByLabelText('Weight'), { target: { value: '110' } });
+    await new Promise(r => setTimeout(r, 500));
+    fireEvent.change(screen.getByLabelText('Weight'), { target: { value: '120' } });
+
+    expect(mockStorage.updateWorkout).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(mockStorage.updateWorkout).toHaveBeenCalledTimes(1);
+    }, { timeout: 3000 });
+  });
+});
+
+describe('Memory Leak Prevention', () => {
+  it('should maintain stable memory usage during extended sessions', async () => {
+    render(<WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />);
+
+    for (let i = 0; i < 100; i++) {
+      act(() => {
+        fireEvent.change(screen.getByLabelText('Weight'), { target: { value: `${i}` } });
+      });
+    }
+
+    expect(setTimeout).toHaveBeenCalledTimes(100);
+    expect(clearTimeout).toHaveBeenCalledTimes(99);
+  });
+
+  it('should handle component unmount gracefully', () => {
+    const { unmount } = render(<WorkoutPage workout={baseWorkout} onNavigateBack={() => {}} />);
+    fireEvent.change(screen.getByLabelText('Weight'), { target: { value: '100' } });
+    unmount();
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+    }).not.toThrow();
+  });
+});

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -48,7 +48,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const { updateWorkout } = useWorkoutStorage();
   const { toast } = useToast();
 
-  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const topRef = useRef<HTMLDivElement>(null);
   const completeRef = useRef<HTMLDivElement>(null);
@@ -83,23 +83,33 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
 
 
   useEffect(() => {
-    if (!autoSaveEnabled || !workout?.id) return;
-
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current);
+    if (autoSaveTimeoutRef.current) {
+      clearTimeout(autoSaveTimeoutRef.current);
     }
 
-    saveTimeoutRef.current = setTimeout(() => {
+    if (!autoSaveEnabled || !workout?.id) {
+      return;
+    }
+
+    autoSaveTimeoutRef.current = setTimeout(() => {
       handleSave();
     }, 2000);
 
     return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-        saveTimeoutRef.current = null;
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current);
+        autoSaveTimeoutRef.current = null;
       }
     };
   }, [workout, autoSaveEnabled, handleSave]);
+
+  useEffect(() => {
+    return () => {
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     // Find the first incomplete exercise


### PR DESCRIPTION
## Summary
- fix cleanup of autosave timeout in `WorkoutPage`
- add unit, integration, and performance tests for autosave logic

## Testing
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a8e9b78dc8329917bcd8e7381187b