### PR TITLE
Implement error boundaries

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,7 @@ import { HistoryPage } from '@/pages/history';
 import { Workout } from '@shared/schema';
 import { Dumbbell, Moon, Sun, Settings } from 'lucide-react';
 import { SettingsDialog } from '@/components/SettingsDialog';
-import ErrorBoundary from '@/components/ErrorBoundary';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 function Navigation() {
   const [location, setLocation] = useLocation();
@@ -117,12 +117,7 @@ function AppContent() {
           )} />
           <Route path="/workout" component={() => (
             currentWorkout ? (
-              <ErrorBoundary fallback={(err, reset) => (
-                <div className="p-4 text-center space-y-4">
-                  <p className="text-sm text-muted-foreground">{err.message}</p>
-                  <Button onClick={reset}>Retry</Button>
-                </div>
-              )}>
+              <ErrorBoundary>
                 <WorkoutPage workout={currentWorkout} onNavigateBack={navigateBack} />
               </ErrorBoundary>
             ) : (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { HistoryPage } from '@/pages/history';
 import { Workout } from '@shared/schema';
 import { Dumbbell, Moon, Sun, Settings } from 'lucide-react';
 import { SettingsDialog } from '@/components/SettingsDialog';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 function Navigation() {
   const [location, setLocation] = useLocation();
@@ -116,7 +117,14 @@ function AppContent() {
           )} />
           <Route path="/workout" component={() => (
             currentWorkout ? (
-              <WorkoutPage workout={currentWorkout} onNavigateBack={navigateBack} />
+              <ErrorBoundary fallback={(err, reset) => (
+                <div className="p-4 text-center space-y-4">
+                  <p className="text-sm text-muted-foreground">{err.message}</p>
+                  <Button onClick={reset}>Retry</Button>
+                </div>
+              )}>
+                <WorkoutPage workout={currentWorkout} onNavigateBack={navigateBack} />
+              </ErrorBoundary>
             ) : (
               <div className="max-w-md mx-auto p-4 text-center">
                 <p className="text-gray-600 dark:text-gray-400">No workout selected</p>

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -17,6 +17,7 @@ import { absLibrary } from '@/lib/abs-library';
 import { useViewStack } from './view-stack-provider';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { cn } from '@/lib/utils';
+import ErrorBoundary from './ErrorBoundary';
 
 interface CustomWorkoutBuilderModalProps {
   open: boolean;
@@ -185,7 +186,8 @@ export function CustomWorkoutBuilderModal({
   };
 
   return (
-    <>
+    <ErrorBoundary>
+      <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-h-[90vh] overflow-y-auto max-w-2xl">
         <DialogHeader className="space-y-1">
@@ -298,6 +300,7 @@ export function CustomWorkoutBuilderModal({
       open={showPreview}
       onOpenChange={setShowPreview}
     />
-    </>
+      </>
+    </ErrorBoundary>
   );
 }

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -186,10 +186,10 @@ export function CustomWorkoutBuilderModal({
   };
 
   return (
-    <ErrorBoundary>
-      <>
+    <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-h-[90vh] overflow-y-auto max-w-2xl">
+          <ErrorBoundary>
         <DialogHeader className="space-y-1">
           <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
           <DialogDescription className="text-left">Select up to 15 exercises and name your workout.</DialogDescription>
@@ -293,6 +293,7 @@ export function CustomWorkoutBuilderModal({
             {template ? 'Update Workout' : 'Save Workout'}
           </Button>
         </div>
+          </ErrorBoundary>
       </DialogContent>
     </Dialog>
     <ExerciseImageDialog
@@ -300,7 +301,6 @@ export function CustomWorkoutBuilderModal({
       open={showPreview}
       onOpenChange={setShowPreview}
     />
-      </>
-    </ErrorBoundary>
+    </>
   );
 }

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -17,7 +17,7 @@ import { absLibrary } from '@/lib/abs-library';
 import { useViewStack } from './view-stack-provider';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { cn } from '@/lib/utils';
-import ErrorBoundary from './ErrorBoundary';
+import { ErrorBoundary } from './ErrorBoundary';
 
 interface CustomWorkoutBuilderModalProps {
   open: boolean;

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Button } from './ui/button';
+
+interface ErrorBoundaryProps {
+  fallback?: React.ReactNode | ((error: Error, reset: () => void) => React.ReactNode);
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null };
+
+  private handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    event.preventDefault();
+    const error = event.reason instanceof Error ? event.reason : new Error(String(event.reason));
+    this.setState({ hasError: true, error });
+    this.reportError(error);
+  };
+
+  private handleErrorEvent = (event: ErrorEvent) => {
+    this.setState({ hasError: true, error: event.error || new Error(event.message) });
+    this.reportError(event.error || new Error(event.message));
+  };
+
+  componentDidMount() {
+    window.addEventListener('unhandledrejection', this.handleUnhandledRejection);
+    window.addEventListener('error', this.handleErrorEvent);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('unhandledrejection', this.handleUnhandledRejection);
+    window.removeEventListener('error', this.handleErrorEvent);
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+    this.reportError(error);
+  }
+
+  private reportError(error: Error) {
+    // Simple error logging. In a real app, send to logging service here.
+    console.error(error);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === 'function') {
+        return this.props.fallback(this.state.error!, this.reset);
+      }
+      return (
+        <div className="p-4 text-center space-y-4">
+          <h2 className="text-lg font-semibold">Something went wrong.</h2>
+          {this.state.error && (
+            <p className="text-sm text-muted-foreground">{this.state.error.message}</p>
+          )}
+          <Button onClick={this.reset}>Retry</Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,8 @@
-import { createRoot } from "react-dom/client";
-import App from "./App";
-import "./index.css";
-import ErrorBoundary from "./components/ErrorBoundary";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 window.addEventListener('unhandledrejection', event => {
   console.error('Unhandled promise rejection:', event.reason);
@@ -10,7 +11,9 @@ window.addEventListener('unhandledrejection', event => {
 const rootEl = document.getElementById("root")!;
 
 createRoot(rootEl).render(
-  <ErrorBoundary>
-    <App />
-  </ErrorBoundary>
+  <React.StrictMode>
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
+  </React.StrictMode>
 );

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
-import ErrorBoundary from '@/components/ErrorBoundary';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 window.addEventListener('unhandledrejection', event => {
   console.error('Unhandled promise rejection:', event.reason);
+  event.preventDefault();
 });
 
 const rootEl = document.getElementById("root")!;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,10 @@ import App from "./App";
 import "./index.css";
 import ErrorBoundary from "./components/ErrorBoundary";
 
+window.addEventListener('unhandledrejection', event => {
+  console.error('Unhandled promise rejection:', event.reason);
+});
+
 const rootEl = document.getElementById("root")!;
 
 createRoot(rootEl).render(

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,12 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import ErrorBoundary from "./components/ErrorBoundary";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const rootEl = document.getElementById("root")!;
+
+createRoot(rootEl).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import './index.css';
-import { ErrorBoundary } from './components/ErrorBoundary';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
-window.addEventListener('unhandledrejection', event => {
+// Add global promise rejection handler
+window.addEventListener('unhandledrejection', (event) => {
   console.error('Unhandled promise rejection:', event.reason);
   event.preventDefault();
 });
 
-const rootEl = document.getElementById("root")!;
-
-createRoot(rootEl).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />
     </ErrorBoundary>
-  </React.StrictMode>
-);
+  </React.StrictMode>,
+)

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -9,6 +9,7 @@ import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from 
 import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
+import ErrorBoundary from '@/components/ErrorBoundary';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate } from '@/lib/storage';
@@ -472,15 +473,17 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onDeleteTemplate={handleDeleteCustomTemplate}
         onEditTemplate={handleEditCustomTemplate}
       />
-        <CustomWorkoutBuilderModal
-          open={currentView === 'customWorkoutBuilder'}
-          onClose={() => { setTemplateToEdit(null); setPrefillTemplate(null); }}
-          onCreate={handleCustomWorkoutCreate}
-          onUpdate={handleCustomWorkoutUpdate}
-          template={templateToEdit ?? undefined}
-          prefill={prefillTemplate ?? undefined}
-          existingNames={customTemplates.map(t => t.name)}
-        />
+        <ErrorBoundary fallback={<div className="p-4">Failed to load builder.</div>}>
+          <CustomWorkoutBuilderModal
+            open={currentView === 'customWorkoutBuilder'}
+            onClose={() => { setTemplateToEdit(null); setPrefillTemplate(null); }}
+            onCreate={handleCustomWorkoutCreate}
+            onUpdate={handleCustomWorkoutUpdate}
+            template={templateToEdit ?? undefined}
+            prefill={prefillTemplate ?? undefined}
+            existingNames={customTemplates.map(t => t.name)}
+          />
+        </ErrorBoundary>
         <AutoScheduleModal
           open={scheduleModalOpen}
           onClose={() => setScheduleModalOpen(false)}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -9,7 +9,7 @@ import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from 
 import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
-import ErrorBoundary from '@/components/ErrorBoundary';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate } from '@/lib/storage';
@@ -473,7 +473,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onDeleteTemplate={handleDeleteCustomTemplate}
         onEditTemplate={handleEditCustomTemplate}
       />
-        <ErrorBoundary fallback={<div className="p-4">Failed to load builder.</div>}>
+        <ErrorBoundary>
           <CustomWorkoutBuilderModal
             open={currentView === 'customWorkoutBuilder'}
             onClose={() => { setTemplateToEdit(null); setPrefillTemplate(null); }}

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import ErrorBoundary from '@/components/ErrorBoundary';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -268,7 +269,8 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   }, [stats.completedItems, stats.totalItems, workout.completed, celebrated]);
 
   return (
-    <>
+    <ErrorBoundary>
+      <>
     <div className="max-w-md mx-auto p-4 space-y-6" ref={topRef}>
       {/* Header */}
       <div className="flex items-center space-x-3">
@@ -447,12 +449,13 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         <h3 className="font-semibold text-gray-900 dark:text-white">Main Workout</h3>
 
         {workout.exercises.map((exercise, index) => (
-          <ExerciseForm
-            key={exercise.machine}
-            exercise={exercise}
-            onUpdate={handleExerciseUpdate}
-            isActive={index === currentExerciseIndex}
-          />
+          <ErrorBoundary key={exercise.machine}>
+            <ExerciseForm
+              exercise={exercise}
+              onUpdate={handleExerciseUpdate}
+              isActive={index === currentExerciseIndex}
+            />
+          </ErrorBoundary>
         ))}
       </div>
 
@@ -491,6 +494,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-    </>
+      </>
+    </ErrorBoundary>
   );
 }

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import ErrorBoundary from '@/components/ErrorBoundary';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -269,9 +269,9 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   }, [stats.completedItems, stats.totalItems, workout.completed, celebrated]);
 
   return (
-    <ErrorBoundary>
-      <>
-    <div className="max-w-md mx-auto p-4 space-y-6" ref={topRef}>
+    <>
+      <ErrorBoundary>
+        <div className="max-w-md mx-auto p-4 space-y-6" ref={topRef}>
       {/* Header */}
       <div className="flex items-center space-x-3">
         <Button
@@ -479,6 +479,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </Button>
       </div>
     </div>
+      </ErrorBoundary>
     <AlertDialog open={showDialog} onOpenChange={handleDialogOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -494,7 +495,6 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-      </>
-    </ErrorBoundary>
+    </>
   );
 }

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -269,9 +269,8 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   }, [stats.completedItems, stats.totalItems, workout.completed, celebrated]);
 
   return (
-    <>
-      <ErrorBoundary>
-        <div className="max-w-md mx-auto p-4 space-y-6" ref={topRef}>
+    <ErrorBoundary>
+      <div className="max-w-md mx-auto p-4 space-y-6" ref={topRef}>
       {/* Header */}
       <div className="flex items-center space-x-3">
         <Button
@@ -478,12 +477,11 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
           {workout.completed ? 'Workout Completed' : 'Complete Workout'}
         </Button>
       </div>
-    </div>
-      </ErrorBoundary>
-    <AlertDialog open={showDialog} onOpenChange={handleDialogOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{successMessage.title}</AlertDialogTitle>
+      </div>
+      <AlertDialog open={showDialog} onOpenChange={handleDialogOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{successMessage.title}</AlertDialogTitle>
           <AlertDialogDescription>
             {successMessage.description}
           </AlertDialogDescription>
@@ -494,7 +492,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
-    </AlertDialog>
-    </>
+      </AlertDialog>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- create a reusable `ErrorBoundary` component
- wrap the main app in an error boundary
- protect WorkoutPage and CustomWorkoutBuilderModal with local error boundaries

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687aa84a219c8329bf9be49f208d931c