### PR TITLE
Fix custom workout template refresh

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -35,6 +35,7 @@ interface CustomWorkoutBuilderModalProps {
     abs: AbsExercise[],
     includeInAutoSchedule: boolean,
   ) => void;
+  refreshCustomTemplates?: () => void;
   template?: CustomWorkoutTemplate | null;
   prefill?: {
     name: string;
@@ -49,6 +50,7 @@ export function CustomWorkoutBuilderModal({
   onClose,
   onCreate,
   onUpdate,
+  refreshCustomTemplates,
   template,
   prefill,
   existingNames,
@@ -153,6 +155,7 @@ export function CustomWorkoutBuilderModal({
       onUpdate(template.id, name, exercises, abs, includeInSchedule);
     } else {
       onCreate(name, exercises, abs, includeInSchedule);
+      refreshCustomTemplates?.();
     }
     popView();
     onClose();

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -204,6 +204,15 @@ export function useWorkoutStorage() {
     }
     return updated;
   };
+  const refreshCustomTemplates = async () => {
+    try {
+      const templatesData = await localWorkoutStorage.getCustomTemplates();
+      setCustomTemplates(templatesData);
+    } catch (err) {
+      console.error("Failed to refresh custom templates", err);
+    }
+  };
+
 
 
   const resetAllData = async () => {
@@ -228,6 +237,7 @@ export function useWorkoutStorage() {
     addCustomTemplate,
     deleteCustomTemplate,
     updateCustomTemplate,
+    refreshCustomTemplates,
     resetAllData,
     exportData,
     exportCSV

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -139,7 +139,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     });
     await loadWorkoutForDate(dateForCreation);
     setPrefillTemplate(null);
-    setDateForCreation(null);
+    // Keep dateForCreation so newly created templates can be immediately selected
   };
 
   const handleCustomWorkoutUpdate = async (
@@ -467,7 +467,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
       <WorkoutTemplateSelectorModal
         open={currentView === 'templateSelector'}
         customTemplates={customTemplates}
-        onClose={() => popView()}
+        onClose={() => {
+          popView();
+          setDateForCreation(null);
+        }}
         onSelectTemplate={handleTemplateSelect}
         onCreateCustom={handleCreateCustom}
         onClonePreset={handleClonePreset}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -38,6 +38,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     addCustomTemplate,
     deleteCustomTemplate,
     updateCustomTemplate,
+    refreshCustomTemplates,
     customTemplates,
     loading
   } = useWorkoutStorage();
@@ -479,6 +480,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
             onClose={() => { setTemplateToEdit(null); setPrefillTemplate(null); }}
             onCreate={handleCustomWorkoutCreate}
             onUpdate={handleCustomWorkoutUpdate}
+            refreshCustomTemplates={refreshCustomTemplates}
             template={templateToEdit ?? undefined}
             prefill={prefillTemplate ?? undefined}
             existingNames={customTemplates.map(t => t.name)}


### PR DESCRIPTION
## Summary
- add `refreshCustomTemplates` helper and export it from workout storage hook
- allow `CustomWorkoutBuilderModal` to refresh template list after save
- plumb the refresh function through calendar page

## Testing
- `npm test` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_687ac6e1b7e08329ac906703caac446b