### PR TITLE
Fix carousel event listener cleanup

### DIFF
--- a/client/src/components/ui/carousel.tsx
+++ b/client/src/components/ui/carousel.tsx
@@ -114,6 +114,7 @@ const Carousel = React.forwardRef<
       api.on("select", onSelect)
 
       return () => {
+        api?.off("reInit", onSelect)
         api?.off("select", onSelect)
       }
     }, [api, onSelect])


### PR DESCRIPTION
## Summary
- clean up reInit event listener in carousel component to avoid memory leak

## Testing
- `npm test -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687acde3bcc88329bc97ed1eecd18dcd