### PR TITLE
Fix toast listener registration

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -181,7 +181,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid re-registering useToast listener on every state change

## Testing
- `npm run check` *(fails: missing test packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ad2146ffc83299aa328db52a096cc