### PR TITLE
Organize groups in custom workout builder

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -76,6 +76,28 @@ export function CustomWorkoutBuilderModal({
     both: { icon: '⚖️', label: 'Both' },
   };
 
+  const regionOrder = [
+    'Chest',
+    'Chest Pecs',
+    'Outer Pecs',
+    'Back',
+    'Shoulders',
+    'Traps',
+    'Biceps',
+    'Triceps',
+    'Outer Triceps',
+    'Forearms',
+    'Quads',
+    'Quads / Hams',
+    'Hamstrings',
+    'Glutes',
+    'Inner Thighs',
+    'Outer Thighs',
+    'Legs (Warm Up)',
+    'Legs',
+    'Calves',
+  ];
+
   useEffect(() => {
     if (open) {
       if (template) {
@@ -181,6 +203,15 @@ export function CustomWorkoutBuilderModal({
     grouped[e.region].push(e);
   });
 
+  const orderedGroups = Object.entries(grouped).sort((a, b) => {
+    const idxA = regionOrder.indexOf(a[0]);
+    const idxB = regionOrder.indexOf(b[0]);
+    if (idxA === -1 && idxB === -1) return a[0].localeCompare(b[0]);
+    if (idxA === -1) return 1;
+    if (idxB === -1) return -1;
+    return idxA - idxB;
+  });
+
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       popView();
@@ -211,7 +242,7 @@ export function CustomWorkoutBuilderModal({
         </div>
         
         <div className="space-y-4 -mt-2">
-          {Object.entries(grouped).map(([region, exercises]) => (
+          {orderedGroups.map(([region, exercises]) => (
             <div key={region} className="border rounded p-2">
               <div className="font-medium mb-2">{region}</div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -76,10 +76,20 @@ export function CustomWorkoutBuilderModal({
     both: { icon: '⚖️', label: 'Both' },
   };
 
+  const regionAliases: Record<string, string> = {
+    'Chest': 'Chest',
+    'Chest Pecs': 'Chest',
+    'Outer Pecs': 'Chest',
+    'Quads': 'Legs',
+    'Quads / Hams': 'Legs',
+    'Legs': 'Legs',
+    'Legs (Warm Up)': 'Legs',
+    'Inner Thighs': 'Thighs',
+    'Outer Thighs': 'Thighs',
+  };
+
   const regionOrder = [
     'Chest',
-    'Chest Pecs',
-    'Outer Pecs',
     'Back',
     'Shoulders',
     'Traps',
@@ -87,14 +97,10 @@ export function CustomWorkoutBuilderModal({
     'Triceps',
     'Outer Triceps',
     'Forearms',
-    'Quads',
-    'Quads / Hams',
+    'Legs',
+    'Thighs',
     'Hamstrings',
     'Glutes',
-    'Inner Thighs',
-    'Outer Thighs',
-    'Legs (Warm Up)',
-    'Legs',
     'Calves',
   ];
 
@@ -199,8 +205,9 @@ export function CustomWorkoutBuilderModal({
 
   const grouped: Record<string, ExerciseOption[]> = {};
   filteredExercises.forEach(e => {
-    if (!grouped[e.region]) grouped[e.region] = [];
-    grouped[e.region].push(e);
+    const region = regionAliases[e.region] ?? e.region;
+    if (!grouped[region]) grouped[region] = [];
+    grouped[region].push(e);
   });
 
   const orderedGroups = Object.entries(grouped).sort((a, b) => {

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -86,6 +86,7 @@ export function CustomWorkoutBuilderModal({
     'Legs (Warm Up)': 'Legs',
     'Inner Thighs': 'Thighs',
     'Outer Thighs': 'Thighs',
+    'Outer Triceps': 'Triceps',
   };
 
   const regionOrder = [
@@ -95,7 +96,6 @@ export function CustomWorkoutBuilderModal({
     'Traps',
     'Biceps',
     'Triceps',
-    'Outer Triceps',
     'Forearms',
     'Legs',
     'Thighs',


### PR DESCRIPTION
## Summary
- add a constant list to define custom ordering of exercise groups
- sort exercise groups in the builder using the new order

## Testing
- `npx -y vitest run` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_687ba95c1cac83299c1cad7d157eef04