### PR TITLE
Fix equipment mode classification

### DIFF
--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -154,7 +154,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Body Squat",
-        equipment: "both",
+        equipment: "freeweight",
         region: "Legs",
         feel: "Medium",
         sets: [
@@ -571,7 +571,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Chest Press",
-        equipment: "machine",
+        equipment: "both",
         region: "Chest",
         feel: "Medium",
         sets: [
@@ -668,7 +668,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Chest Press",
-        equipment: "machine",
+        equipment: "both",
         region: "Chest",
         feel: "Medium",
         sets: [
@@ -682,7 +682,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Push Up (on Knees)",
-        equipment: "both",
+        equipment: "freeweight",
         region: "Chest",
         feel: "Light",
         sets: [
@@ -696,7 +696,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Seated Shoulder Press",
-        equipment: "machine",
+        equipment: "both",
         region: "Shoulders",
         feel: "Medium",
         sets: [
@@ -710,7 +710,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
       {
         code: "N/A",
         machine: "Cable Front Deltoid Raise",
-        equipment: "machine",
+        equipment: "both",
         region: "Shoulders",
         feel: "Medium",
         sets: [


### PR DESCRIPTION
## Summary
- adjust workout equipment tags so bodyweight moves use `freeweight`
- mark certain exercises as available with machines or weights

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbb3821488329b3d06b14ae62c94b