### PR TITLE
Add preset visibility sync

### DIFF
--- a/client/src/components/AutoScheduleModal.tsx
+++ b/client/src/components/AutoScheduleModal.tsx
@@ -152,6 +152,7 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
   };
 
   return (
+    <>
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="space-y-4">
         <DialogHeader>
@@ -215,5 +216,6 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+    </>
   );
 }

--- a/client/src/components/AutoScheduleModal.tsx
+++ b/client/src/components/AutoScheduleModal.tsx
@@ -137,6 +137,7 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
 
   const finalize = (hide: boolean) => {
     if (!pendingPresets) return;
+    setPendingPresets(null);
     setDraftHidden(prev => {
       const updated = { ...prev };
       pendingPresets.forEach(name => {

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -64,6 +64,9 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           <Button className="w-full" variant="secondary" onClick={() => setScheduleOpen(true)}>
             Customize Auto-Schedule
           </Button>
+          <Button className="w-full" variant="secondary" onClick={() => { localWorkoutStorage.saveHiddenPresets({}); toast({ title: 'Presets restored', description: 'All presets are visible.' }); }}>
+            Show hidden presets
+          </Button>
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="destructive" className="w-full">Reset All Data</Button>

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -5,9 +5,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { CustomWorkoutTemplate } from '@/lib/storage';
+import { CustomWorkoutTemplate, localWorkoutStorage } from '@/lib/storage';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -30,6 +31,23 @@ interface WorkoutTemplateSelectorModalProps {
 
 export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onClonePreset, onDeleteTemplate, onEditTemplate }: WorkoutTemplateSelectorModalProps) {
   const { pushView } = useViewStack();
+  const [hiddenPresets, setHiddenPresets] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (open) {
+      setHiddenPresets(localWorkoutStorage.getHiddenPresets());
+    }
+  }, [open]);
+  const presetList = [
+    'Chest Day',
+    'Legs',
+    'Back & Biceps',
+    'Back, Biceps & Legs',
+    'Chest & Triceps',
+    'Chest & Shoulders',
+    'Chest, Shoulders & Legs',
+  ];
+  const visiblePresets = presetList.filter(name => !hiddenPresets[name]);
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose();
@@ -46,15 +64,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col space-y-2">
-          {[
-            'Chest Day',
-            'Legs',
-            'Back & Biceps',
-            'Back, Biceps & Legs',
-            'Chest & Triceps',
-            'Chest & Shoulders',
-            'Chest, Shoulders & Legs',
-          ].map(name => (
+          {visiblePresets.map(name => (
             <div key={name} className="flex items-center space-x-1">
               <Button
                 variant="outline"

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -15,7 +15,9 @@ const STORAGE_KEYS = {
   CURRENT_ID: 'ironpath_current_id',
   EXERCISE_HISTORY: 'ironpath_exercise_history',
   CUSTOM_TEMPLATES: 'ironpath_custom_templates',
-  AUTO_SCHEDULE_WORKOUTS: 'ironpath_auto_schedule_workouts'
+  AUTO_SCHEDULE_WORKOUTS: 'ironpath_auto_schedule_workouts',
+  HIDDEN_PRESETS: 'ironpath_hidden_presets',
+  PRESET_PROMPTS: 'ironpath_preset_prompts'
 } as const;
 
 
@@ -217,6 +219,34 @@ export class LocalWorkoutStorage {
     } catch {
       return [];
     }
+  }
+
+  getHiddenPresets(): Record<string, boolean> {
+    try {
+      const stored = this.safeGetItem(STORAGE_KEYS.HIDDEN_PRESETS);
+      const parsed = stored ? JSON.parse(stored) : {};
+      return typeof parsed === 'object' && parsed !== null ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  saveHiddenPresets(presets: Record<string, boolean>): void {
+    this.safeSetItem(STORAGE_KEYS.HIDDEN_PRESETS, JSON.stringify(presets));
+  }
+
+  getPresetPromptPrefs(): Record<string, boolean> {
+    try {
+      const stored = this.safeGetItem(STORAGE_KEYS.PRESET_PROMPTS);
+      const parsed = stored ? JSON.parse(stored) : {};
+      return typeof parsed === 'object' && parsed !== null ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  savePresetPromptPrefs(prefs: Record<string, boolean>): void {
+    this.safeSetItem(STORAGE_KEYS.PRESET_PROMPTS, JSON.stringify(prefs));
   }
 
   saveAutoScheduleWorkouts(names: string[]): void {


### PR DESCRIPTION
## Summary
- support storing hidden presets and dismissal prefs in storage
- prompt to hide preset when removing from auto-schedule
- hide removed presets in workout template selector
- allow restoring hidden presets via settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c34eb8adc83299ec2eb48d5d8bf37