### PR TITLE
Add Customize Streak modal

### DIFF
--- a/client/src/components/CustomizeStreakModal.tsx
+++ b/client/src/components/CustomizeStreakModal.tsx
@@ -65,6 +65,10 @@ export function CustomizeStreakModal({ open, onClose }: CustomizeStreakModalProp
           <DialogDescription>
             Choose which days count toward your streak
           </DialogDescription>
+          <p className="text-sm text-muted-foreground">
+            You can still work out on other days — only missed planned days break your
+            streak. Bonus workouts help but don’t hurt.
+          </p>
         </DialogHeader>
         <div className="space-y-2">
           {days.map((day, idx) => (

--- a/client/src/components/CustomizeStreakModal.tsx
+++ b/client/src/components/CustomizeStreakModal.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { localWorkoutStorage } from '@/lib/storage';
+
+interface CustomizeStreakModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+export function CustomizeStreakModal({ open, onClose }: CustomizeStreakModalProps) {
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (open) {
+      const stored = localWorkoutStorage.getStreakDays();
+      setSelected(new Set(stored));
+    }
+  }, [open]);
+
+  const toggle = (idx: number) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    localWorkoutStorage.saveStreakDays(Array.from(selected).sort());
+    onClose();
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>Customize Streak</DialogTitle>
+          <DialogDescription>
+            Choose which days count toward your streak
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          {days.map((day, idx) => (
+            <label key={day} className="flex items-center space-x-2 text-sm">
+              <Checkbox
+                checked={selected.has(idx)}
+                onCheckedChange={() => toggle(idx)}
+              />
+              <span>{day}</span>
+            </label>
+          ))}
+        </div>
+        <DialogFooter className="pt-2">
+          <Button variant="secondary" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={handleSave} type="button">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -17,7 +17,8 @@ const STORAGE_KEYS = {
   CUSTOM_TEMPLATES: 'ironpath_custom_templates',
   AUTO_SCHEDULE_WORKOUTS: 'ironpath_auto_schedule_workouts',
   HIDDEN_PRESETS: 'ironpath_hidden_presets',
-  PRESET_PROMPTS: 'ironpath_preset_prompts'
+  PRESET_PROMPTS: 'ironpath_preset_prompts',
+  STREAK_DAYS: 'ironpath_streak_days'
 } as const;
 
 
@@ -254,6 +255,23 @@ export class LocalWorkoutStorage {
       STORAGE_KEYS.AUTO_SCHEDULE_WORKOUTS,
       JSON.stringify(names)
     );
+  }
+
+  getStreakDays(): number[] {
+    try {
+      const stored = this.safeGetItem(STORAGE_KEYS.STREAK_DAYS);
+      const parsed = stored ? JSON.parse(stored) : null;
+      const defaultDays = [0, 1, 2, 3, 4, 5, 6];
+      return Array.isArray(parsed)
+        ? parsed.filter(d => typeof d === 'number')
+        : defaultDays;
+    } catch {
+      return [0, 1, 2, 3, 4, 5, 6];
+    }
+  }
+
+  saveStreakDays(days: number[]): void {
+    this.safeSetItem(STORAGE_KEYS.STREAK_DAYS, JSON.stringify(days));
   }
 
   async getLastExerciseSets(machine: string): Promise<{ weight: number; reps: number; rest?: string }[] | undefined> {

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -370,17 +370,14 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
             <div className="text-sm text-gray-600 dark:text-gray-400">Completed</div>
           </CardContent>
         </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-green-600">{stats.currentStreak}</div>
-            <div className="text-sm text-gray-600 dark:text-gray-400 flex items-center justify-center gap-1">
-              <span>Day Streak</span>
-              <Button variant="link" size="sm" onClick={() => setStreakModalOpen(true)}>
-                Customize
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <button
+          type="button"
+          onClick={() => setStreakModalOpen(true)}
+          className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 text-center cursor-pointer transition-colors hover:bg-accent/50 active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="text-2xl font-bold text-green-600">{stats.currentStreak}</div>
+          <div className="text-sm text-gray-600 dark:text-gray-400">Day Streak</div>
+        </button>
         <Card>
           <CardContent className="p-4 text-center">
             <div className="text-2xl font-bold text-orange-600">{stats.totalWorkouts}</div>

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -11,6 +11,7 @@ import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelect
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
+import { CustomizeStreakModal } from '@/components/CustomizeStreakModal';
 import { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate } from '@/lib/storage';
 
@@ -26,6 +27,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const { currentView, pushView, popView } = useViewStack();
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
+  const [streakModalOpen, setStreakModalOpen] = useState(false);
   const [templateToEdit, setTemplateToEdit] = useState<CustomWorkoutTemplate | null>(null);
   const [prefillTemplate, setPrefillTemplate] = useState<{ name: string; exercises: Exercise[]; abs: AbsExercise[] } | null>(null);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
@@ -371,7 +373,12 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         <Card>
           <CardContent className="p-4 text-center">
             <div className="text-2xl font-bold text-green-600">{stats.currentStreak}</div>
-            <div className="text-sm text-gray-600 dark:text-gray-400">Day Streak</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400 flex items-center justify-center gap-1">
+              <span>Day Streak</span>
+              <Button variant="link" size="sm" onClick={() => setStreakModalOpen(true)}>
+                Customize
+              </Button>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -493,6 +500,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
           open={scheduleModalOpen}
           onClose={() => setScheduleModalOpen(false)}
           customTemplates={customTemplates}
+        />
+        <CustomizeStreakModal
+          open={streakModalOpen}
+          onClose={() => setStreakModalOpen(false)}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- add `CustomizeStreakModal` component for selecting streak days
- persist selected days via new `STREAK_DAYS` key in storage
- expose modal from calendar stats card

## Testing
- `npx vitest` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_687fb8f045a48329a278b0e7ae11658e