### PR TITLE
Fix inconsistent streak display

### DIFF
--- a/client/src/lib/streak.ts
+++ b/client/src/lib/streak.ts
@@ -1,0 +1,34 @@
+import { Workout } from '@shared/schema';
+import { parseISODate, formatLocalDate } from '@/lib/utils';
+
+export function calculateDayStreak(workouts: Workout[], streakDays: number[]): number {
+  const workoutMap = new Map(workouts.map(w => [w.date, w.completed]));
+  const lastCompleted = workouts
+    .filter(w => w.completed)
+    .map(w => parseISODate(w.date))
+    .sort((a, b) => b.getTime() - a.getTime())[0];
+
+  const startDate = lastCompleted && lastCompleted > new Date() ? lastCompleted : new Date();
+  let streak = 0;
+  const date = new Date(startDate);
+
+  for (let i = 0; i < 365; i++) {
+    const dateString = formatLocalDate(date);
+    const completed = workoutMap.get(dateString) ?? false;
+    const isStreakDay = streakDays.includes(date.getDay());
+
+    if (isStreakDay) {
+      if (completed) {
+        streak++;
+      } else {
+        break;
+      }
+    } else if (completed) {
+      streak++;
+    }
+
+    date.setDate(date.getDate() - 1);
+  }
+
+  return streak;
+}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -7,6 +7,7 @@ import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
+import { calculateDayStreak } from '@/lib/streak';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -306,43 +307,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const getWorkoutStats = () => {
     const completedWorkouts = workouts.filter(w => w.completed).length;
     const totalWorkouts = workouts.length;
-    const currentStreak = calculateCurrentStreak();
-    
-    return { completedWorkouts, totalWorkouts, currentStreak };
-  };
-
-  const calculateCurrentStreak = () => {
     const streakDays = localWorkoutStorage.getStreakDays();
-    const workoutMap = new Map(workouts.map(w => [w.date, w.completed]));
+    const currentStreak = calculateDayStreak(workouts, streakDays);
 
-    const lastCompleted = workouts
-      .filter(w => w.completed)
-      .map(w => parseISODate(w.date))
-      .sort((a, b) => b.getTime() - a.getTime())[0];
-
-    const startDate = lastCompleted && lastCompleted > new Date() ? lastCompleted : new Date();
-    let streak = 0;
-    const date = new Date(startDate);
-
-    for (let i = 0; i < 365; i++) {
-      const dateString = formatLocalDate(date);
-      const completed = workoutMap.get(dateString) ?? false;
-      const isStreakDay = streakDays.includes(date.getDay());
-
-      if (isStreakDay) {
-        if (completed) {
-          streak++;
-        } else {
-          break;
-        }
-      } else if (completed) {
-        streak++;
-      }
-
-      date.setDate(date.getDate() - 1);
-    }
-
-    return streak;
+    return { completedWorkouts, totalWorkouts, currentStreak };
   };
 
   if (loading) {

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -6,6 +6,8 @@ import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { Workout } from '@shared/schema';
 import { BarChart, Calendar, Download, FileText, TrendingUp } from 'lucide-react';
 import { parseISODate } from '@/lib/utils';
+import { calculateDayStreak } from '@/lib/streak';
+import { localWorkoutStorage } from '@/lib/storage';
 
 export function HistoryPage() {
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month' | 'year'>('month');
@@ -70,25 +72,8 @@ export function HistoryPage() {
     const totalDuration = completed.reduce((sum, w) => sum + (w.duration || 0), 0);
     const avgDuration = totalWorkouts > 0 ? Math.round(totalDuration / totalWorkouts) : 0;
 
-    const sortedWorkouts = [...workouts]
-      .filter(w => w.completed)
-      .sort(
-        (a, b) =>
-          parseISODate(b.date).getTime() - parseISODate(a.date).getTime()
-      );
-
-    let currentStreak = 0;
-    const today = new Date();
-
-    for (let i = 0; i < sortedWorkouts.length; i++) {
-      const workoutDate = parseISODate(sortedWorkouts[i].date);
-      const diffDays = Math.floor((today.getTime() - workoutDate.getTime()) / (1000 * 60 * 60 * 24));
-      if (diffDays === currentStreak) {
-        currentStreak++;
-      } else {
-        break;
-      }
-    }
+    const streakDays = localWorkoutStorage.getStreakDays();
+    const currentStreak = calculateDayStreak(workouts, streakDays);
 
     const weightProgress = calculateWeightProgress(completed);
 


### PR DESCRIPTION
## Summary
- add `calculateDayStreak` helper
- use the helper on Calendar and History pages
- remove old duplicated streak logic

## Testing
- `npx vitest run` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68802af0c73c8329a79053160dff4f4d