### PR TITLE
Add longest streak tile

### DIFF
--- a/client/src/lib/streak.ts
+++ b/client/src/lib/streak.ts
@@ -32,3 +32,45 @@ export function calculateDayStreak(workouts: Workout[], streakDays: number[]): n
 
   return streak;
 }
+
+export function calculateLongestDayStreak(workouts: Workout[], streakDays: number[]): number {
+  if (workouts.length === 0) return 0;
+
+  const workoutMap = new Map(workouts.map(w => [w.date, w.completed]));
+  const sortedDates = workouts
+    .map(w => parseISODate(w.date))
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  const startDate = sortedDates[0];
+  const endDate = (() => {
+    const last = sortedDates[sortedDates.length - 1];
+    const today = new Date();
+    return last > today ? last : today;
+  })();
+
+  let current = 0;
+  let longest = 0;
+  const date = new Date(startDate);
+
+  while (date <= endDate) {
+    const dateString = formatLocalDate(date);
+    const completed = workoutMap.get(dateString) ?? false;
+    const isStreakDay = streakDays.includes(date.getDay());
+
+    if (isStreakDay) {
+      if (completed) {
+        current++;
+        if (current > longest) longest = current;
+      } else {
+        current = 0;
+      }
+    } else if (completed) {
+      current++;
+      if (current > longest) longest = current;
+    }
+
+    date.setDate(date.getDate() + 1);
+  }
+
+  return longest;
+}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -7,7 +7,7 @@ import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
-import { calculateDayStreak } from '@/lib/streak';
+import { calculateDayStreak, calculateLongestDayStreak } from '@/lib/streak';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -306,11 +306,11 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
 
   const getWorkoutStats = () => {
     const completedWorkouts = workouts.filter(w => w.completed).length;
-    const totalWorkouts = workouts.length;
     const streakDays = localWorkoutStorage.getStreakDays();
     const currentStreak = calculateDayStreak(workouts, streakDays);
+    const longestStreak = calculateLongestDayStreak(workouts, streakDays);
 
-    return { completedWorkouts, totalWorkouts, currentStreak };
+    return { completedWorkouts, currentStreak, longestStreak };
   };
 
   if (loading) {
@@ -362,8 +362,8 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         </button>
         <Card>
           <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-orange-600">{stats.totalWorkouts}</div>
-            <div className="text-sm text-gray-600 dark:text-gray-400">Total</div>
+            <div className="text-2xl font-bold text-orange-600">{stats.longestStreak}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400">Longest Streak</div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- compute user's longest streak of completed scheduled workout days
- display longest streak on Calendar page instead of Total workouts

## Testing
- `npm run check`
- `npm test` *(fails: spy expectations and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68803518b95083299430d7ff4a8f826c