### PR TITLE
Disable image preview for select ab exercises

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -64,6 +64,19 @@ export function CustomWorkoutBuilderModal({
   const [showPreview, setShowPreview] = useState(false);
   const [equipmentFilter, setEquipmentFilter] = useState<'freeweight' | 'machine' | 'both'>('both');
 
+  const noPreviewAbs = new Set([
+    'Cross-Leg Crunch',
+    'Jack Knife',
+    'Legs-Up Vertical Crunch',
+    'Side Oblique Crunch',
+    'Side Oblique Leg Raise',
+    'Crunch',
+    'Knee Raise',
+    'Reverse Crunch',
+    'Side Oblique Knee Raise',
+    'Straight Leg Thrust',
+  ]);
+
   const cycleFilter = () => {
     setEquipmentFilter(prev =>
       prev === 'freeweight' ? 'machine' : prev === 'machine' ? 'both' : 'freeweight'
@@ -201,6 +214,7 @@ export function CustomWorkoutBuilderModal({
   };
 
   const handlePreview = (name: string) => {
+    if (noPreviewAbs.has(name)) return;
     setPreviewExercise(name);
     setShowPreview(true);
   };


### PR DESCRIPTION
## Summary
- avoid showing the image preview dialog for several ab exercises that don't have images

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68855d330e588329a14cd83eb1446f35