### PR TITLE
Rename Longest Streak to Top Streak

### DIFF
--- a/client/src/lib/streak.ts
+++ b/client/src/lib/streak.ts
@@ -33,7 +33,7 @@ export function calculateDayStreak(workouts: Workout[], streakDays: number[]): n
   return streak;
 }
 
-export function calculateLongestDayStreak(workouts: Workout[], streakDays: number[]): number {
+export function calculateTopDayStreak(workouts: Workout[], streakDays: number[]): number {
   if (workouts.length === 0) return 0;
 
   const workoutMap = new Map(workouts.map(w => [w.date, w.completed]));
@@ -49,7 +49,7 @@ export function calculateLongestDayStreak(workouts: Workout[], streakDays: numbe
   })();
 
   let current = 0;
-  let longest = 0;
+  let top = 0;
   const date = new Date(startDate);
 
   while (date <= endDate) {
@@ -60,17 +60,17 @@ export function calculateLongestDayStreak(workouts: Workout[], streakDays: numbe
     if (isStreakDay) {
       if (completed) {
         current++;
-        if (current > longest) longest = current;
+        if (current > top) top = current;
       } else {
         current = 0;
       }
     } else if (completed) {
       current++;
-      if (current > longest) longest = current;
+      if (current > top) top = current;
     }
 
     date.setDate(date.getDate() + 1);
   }
 
-  return longest;
+  return top;
 }

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -8,7 +8,7 @@ import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
-import { calculateDayStreak, calculateLongestDayStreak } from '@/lib/streak';
+import { calculateDayStreak, calculateTopDayStreak } from '@/lib/streak';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -310,9 +310,9 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     const completedWorkouts = workouts.filter(w => w.completed).length;
     const streakDays = localWorkoutStorage.getStreakDays();
     const currentStreak = calculateDayStreak(workouts, streakDays);
-    const longestStreak = calculateLongestDayStreak(workouts, streakDays);
+    const topStreak = calculateTopDayStreak(workouts, streakDays);
 
-    return { completedWorkouts, currentStreak, longestStreak };
+    return { completedWorkouts, currentStreak, topStreak };
   };
 
   if (loading) {
@@ -369,8 +369,8 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
           onClick={() => setLocation('/history')}
           className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 text-center cursor-pointer transition-colors hover:bg-accent/50 active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <div className="text-2xl font-bold text-orange-600">{stats.longestStreak}</div>
-          <div className="text-sm text-gray-600 dark:text-gray-400">Longest Streak</div>
+          <div className="text-2xl font-bold text-orange-600">{stats.topStreak}</div>
+          <div className="text-sm text-gray-600 dark:text-gray-400">Top Streak</div>
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- rename `calculateLongestDayStreak` to `calculateTopDayStreak`
- update calendar page to use Top Streak wording

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688659bce9348329ae3ca2f2d9c0e602