### PR TITLE
Add hook to set cursor at end on focus

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -6,6 +6,7 @@ import { Exercise, ExerciseSet } from '@shared/schema';
 import { Check, Clock, HelpCircle } from 'lucide-react';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';
+import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
 
 interface ExerciseFormProps {
   exercise: Exercise;
@@ -20,6 +21,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   );
   const [showHelp, setShowHelp] = useState(false);
   const { toast } = useToast();
+  const focusToEnd = useCursorEndOnFocus();
 
   const isSetComplete = (set: ExerciseSet) =>
     set.weight !== undefined && set.reps !== undefined;
@@ -157,8 +159,9 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 </span>
                 
                 <Input
-                  type="number"
+                  type="text"
                   inputMode="decimal"
+                  pattern="[0-9]*"
                   aria-label="Weight"
                   value={set.weight ?? ''}
                   onChange={(e) => {
@@ -167,6 +170,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                       updateSet(index, 'weight', v === '' ? undefined : parseInt(v));
                     }
                   }}
+                  onFocus={focusToEnd}
                   className={`w-16 text-sm ${weightError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="lbs"
                   disabled={false}
@@ -175,8 +179,9 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 <span className="text-xs text-gray-500 dark:text-gray-400">×</span>
                 
                 <Input
-                  type="number"
+                  type="text"
                   inputMode="decimal"
+                  pattern="[0-9]*"
                   value={set.reps ?? ''}
                   onChange={(e) => {
                     const v = e.target.value;
@@ -184,6 +189,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                       updateSet(index, 'reps', v === '' ? undefined : parseInt(v));
                     }
                   }}
+                  onFocus={focusToEnd}
                   className={`w-14 text-sm ${repsError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="reps"
                   disabled={false}

--- a/client/src/hooks/use-cursor-end-on-focus.ts
+++ b/client/src/hooks/use-cursor-end-on-focus.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react'
+
+export function useCursorEndOnFocus() {
+  return useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    const input = e.target as HTMLInputElement
+    const end = input.value.length
+    requestAnimationFrame(() => {
+      try {
+        input.setSelectionRange(end, end)
+      } catch {
+        // some input types (e.g., number) may not support setSelectionRange
+      }
+    })
+  }, [])
+}

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -10,6 +10,7 @@ import { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate, minutesFromDuration } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
 import confetti from 'canvas-confetti';
 import {
   AlertDialog,
@@ -48,6 +49,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const [successMessage, setSuccessMessage] = useState<typeof successMessages[number]>(successMessages[0]);
   const { updateWorkout } = useWorkoutStorage();
   const { toast, dismiss } = useToast();
+  const focusToEnd = useCursorEndOnFocus();
 
   useEffect(() => {
     setWorkout(initialWorkout);
@@ -349,11 +351,14 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                       {absExercise.reps !== undefined ? (
                         <>
                           <Input
-                            type="number"
+                            type="text"
+                            inputMode="decimal"
+                            pattern="[0-9]*"
                             value={absExercise.reps}
                             onChange={(e) =>
                               handleAbsUpdate(index, 'reps', parseInt(e.target.value) || 0)
                             }
+                            onFocus={focusToEnd}
                             className="w-16 text-sm"
                             placeholder="reps"
                           />


### PR DESCRIPTION
## Summary
- create `useCursorEndOnFocus` hook
- use hook on weight and reps fields
- update warmup reps input to use the hook

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6889609e93688329858ef55bc51c1eb4